### PR TITLE
[Feat/#4] 할 일 수정 및 삭제 API

### DIFF
--- a/src/main/java/beyond/samdasoo/todo/controller/TodoController.java
+++ b/src/main/java/beyond/samdasoo/todo/controller/TodoController.java
@@ -2,6 +2,7 @@ package beyond.samdasoo.todo.controller;
 
 import beyond.samdasoo.todo.dto.TodoRequestDto;
 import beyond.samdasoo.todo.dto.TodoResponseDto;
+import beyond.samdasoo.todo.dto.TodoUpdateDto;
 import beyond.samdasoo.todo.service.TodoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -31,4 +32,15 @@ public class TodoController {
         return ResponseEntity.ok(responseDto);
     }
 
+    @PatchMapping("/{no}")
+    public ResponseEntity<Void> patchUpdateTodo(@PathVariable("no") Long no, @RequestBody TodoUpdateDto todoUpdateDto) {
+        todoService.updateTodo(no, todoUpdateDto);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{no}")
+    public ResponseEntity<Void> deleteTodo(@PathVariable("no") Long no) {
+        todoService.deleteTodo(no);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/beyond/samdasoo/todo/dto/TodoRequestDto.java
+++ b/src/main/java/beyond/samdasoo/todo/dto/TodoRequestDto.java
@@ -13,8 +13,6 @@ public class TodoRequestDto {
     private String todoCls;
     private String priority;
     private Date dueDate;
-    private String notiYn;
-    private String notiDay;
     private TodoStatus status;
     private String privateYn;
     private String content;

--- a/src/main/java/beyond/samdasoo/todo/dto/TodoResponseDto.java
+++ b/src/main/java/beyond/samdasoo/todo/dto/TodoResponseDto.java
@@ -14,8 +14,6 @@ public class TodoResponseDto {
     private String todoCls;
     private String priority;
     private Date dueDate;
-    private String notiYn;
-    private String notiDay;
     private TodoStatus status;
     private String privateYn;
     private String content;
@@ -27,8 +25,6 @@ public class TodoResponseDto {
         this.todoCls = todo.getTodoCls();
         this.priority = todo.getPriority();
         this.dueDate = todo.getDueDate();
-        this.notiYn = todo.getNotiYn();
-        this.notiDay = todo.getNotiDay();
         this.status = todo.getStatus();
         this.privateYn = todo.getPrivateYn();
         this.content = todo.getContent();

--- a/src/main/java/beyond/samdasoo/todo/dto/TodoUpdateDto.java
+++ b/src/main/java/beyond/samdasoo/todo/dto/TodoUpdateDto.java
@@ -1,0 +1,17 @@
+package beyond.samdasoo.todo.dto;
+
+import beyond.samdasoo.todo.entity.TodoStatus;
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class TodoUpdateDto {
+    private String title;
+    private String todoCls;
+    private String priority;
+    private Date dueDate;
+    private String privateYn;
+    private String content;
+    private TodoStatus status;
+}

--- a/src/main/java/beyond/samdasoo/todo/entity/Todo.java
+++ b/src/main/java/beyond/samdasoo/todo/entity/Todo.java
@@ -3,11 +3,17 @@ package beyond.samdasoo.todo.entity;
 import beyond.samdasoo.common.entity.BaseEntity;
 import beyond.samdasoo.member.entity.Member;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.Date;
 
 @Table(name="tb_todo")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Entity
 @Data
 public class Todo extends BaseEntity {
@@ -32,11 +38,12 @@ public class Todo extends BaseEntity {
     @Column(name = "due_date")
     private Date dueDate;
 
-    @Column(name = "noti_yn", length = 1)
-    private String notiYn;
-
-    @Column(name = "noti_day")
-    private String notiDay;
+//    TODO: 알람기능 필요 시 추가하도록
+//    @Column(name = "noti_yn", length = 1)
+//    private String notiYn;
+//
+//    @Column(name = "noti_day")
+//    private String notiDay;
 
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/beyond/samdasoo/todo/service/TodoService.java
+++ b/src/main/java/beyond/samdasoo/todo/service/TodoService.java
@@ -4,12 +4,15 @@ import beyond.samdasoo.member.entity.Member;
 import beyond.samdasoo.member.repository.MemberRepository;
 import beyond.samdasoo.todo.dto.TodoRequestDto;
 import beyond.samdasoo.todo.dto.TodoResponseDto;
+import beyond.samdasoo.todo.dto.TodoUpdateDto;
 import beyond.samdasoo.todo.entity.Todo;
 import beyond.samdasoo.todo.repository.TodoRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 public class TodoService {
@@ -30,17 +33,16 @@ public class TodoService {
         Member member = memberRepository.findById(todoRequestDto.getMemberNo())
                 .orElseThrow(() -> new EntityNotFoundException("회원 ID 조회 불가: " + todoRequestDto.getMemberNo()));
 
-        Todo todo = new Todo();
-        todo.setTitle(todoRequestDto.getTitle());
-        todo.setTodoCls(todoRequestDto.getTodoCls());
-        todo.setPriority(todoRequestDto.getPriority());
-        todo.setDueDate(todoRequestDto.getDueDate());
-        todo.setNotiYn(todoRequestDto.getNotiYn());
-        todo.setNotiDay(todoRequestDto.getNotiDay());
-        todo.setStatus(todoRequestDto.getStatus());
-        todo.setPrivateYn(todoRequestDto.getPrivateYn());
-        todo.setContent(todoRequestDto.getContent());
-        todo.setMemberNo(member);
+        Todo todo = Todo.builder()
+                .title(todoRequestDto.getTitle())
+                .todoCls(todoRequestDto.getTodoCls())
+                .priority(todoRequestDto.getPriority())
+                .dueDate(todoRequestDto.getDueDate())
+                .status(todoRequestDto.getStatus())
+                .privateYn(todoRequestDto.getPrivateYn())
+                .content(todoRequestDto.getContent())
+                .memberNo(member)
+                .build();
 
         todo = todoRepository.save(todo);
 
@@ -48,11 +50,30 @@ public class TodoService {
     }
 
     @Transactional(readOnly = true)
-    public TodoResponseDto getTodoById(Long id) {
-        Todo todo = todoRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("할 일을 찾을 수 없습니다: " + id));
+    public TodoResponseDto getTodoById(Long no) {
+        Todo todo = todoRepository.findById(no)
+                .orElseThrow(() -> new RuntimeException("할 일을 찾을 수 없습니다: " + no));
         return new TodoResponseDto(todo);
     }
 
+    @Transactional
+    public void updateTodo(Long no, TodoUpdateDto todoUpdateDto) {
+        Todo todo = todoRepository.findById(no)
+                .orElseThrow(() -> new EntityNotFoundException("할 일을 찾을 수 없습니다: " + no));
 
+        Optional.ofNullable(todoUpdateDto.getTitle()).ifPresent(todo::setTitle);
+        Optional.ofNullable(todoUpdateDto.getTodoCls()).ifPresent(todo::setTodoCls);
+        Optional.ofNullable(todoUpdateDto.getPriority()).ifPresent(todo::setPriority);
+        Optional.ofNullable(todoUpdateDto.getDueDate()).ifPresent(todo::setDueDate);
+        Optional.ofNullable(todoUpdateDto.getPrivateYn()).ifPresent(todo::setPrivateYn);
+        Optional.ofNullable(todoUpdateDto.getContent()).ifPresent(todo::setContent);
+        Optional.ofNullable(todoUpdateDto.getStatus()).ifPresent(todo::setStatus);
+    }
+
+    public void deleteTodo(Long no) {
+        Todo todo = todoRepository.findById(no)
+                .orElseThrow(() -> new RuntimeException("할 일을 찾을 수 없습니다: " + no));
+
+        todoRepository.delete(todo);
+    }
 }


### PR DESCRIPTION
## 📢 작업 내용 설명
- 할 일 수정 API
- 할 일 삭제 API
- 할 일 엔티티 및 생성 서비스에 빌드 패턴 적용
- `notiDay`, `notiYn` 등 알람 관련 필드 주석처리(후에 필요 시 개발)
- 파라미터 변수 `no`로 통일

<br>

<details>
  <summary> 할 일 수정 </summary>

![image](https://github.com/user-attachments/assets/1050d241-bc26-43bc-93c6-47ca69a54665)

</details>
<details>
  <summary> 할 일 삭제 </summary>

![image](https://github.com/user-attachments/assets/c8456f8f-670f-49e2-8fe0-16c9850bfbdf)

</details>

<br>

## #️⃣연관된  issue
#4

<br>



## ✅ 체크리스트
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정

<br>


### 📑To Reviewers 
pr 잘못 만들어서 다시 올립니다 
알람 죄송합니다... 😢 