### PR TITLE
[Feat/#8] 영업활동 등록, 조회, 수정, 삭제 API

### DIFF
--- a/src/main/java/beyond/samdasoo/act/controller/ActController.java
+++ b/src/main/java/beyond/samdasoo/act/controller/ActController.java
@@ -1,0 +1,42 @@
+package beyond.samdasoo.act.controller;
+
+import beyond.samdasoo.act.dto.ActRequestDto;
+import beyond.samdasoo.act.dto.ActResponseDto;
+import beyond.samdasoo.act.service.ActService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/act")
+public class ActController {
+    private final ActService actService;
+
+    @Autowired
+    public ActController(ActService actService) { this.actService = actService; }
+
+
+    @PostMapping
+    public ResponseEntity<ActResponseDto> createAct(@RequestBody ActRequestDto actRequestDto) {
+        ActResponseDto responseDto = actService.createAct(actRequestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/{no}")
+    public ResponseEntity<ActResponseDto> getActById(@PathVariable("no") Long no) {
+        ActResponseDto responseDto = actService.getActById(no);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @PatchMapping("/{no}")
+    public ResponseEntity<Void> patchUpdateAct(@PathVariable("no") Long no, @RequestBody ActRequestDto actUpdateDto) {
+        actService.updateAct(no, actUpdateDto);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{no}")
+    public ResponseEntity<Void> deleteAct(@PathVariable("no") Long no) {
+        actService.deleteAct(no);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/beyond/samdasoo/act/dto/ActRequestDto.java
+++ b/src/main/java/beyond/samdasoo/act/dto/ActRequestDto.java
@@ -1,0 +1,22 @@
+package beyond.samdasoo.act.dto;
+
+import beyond.samdasoo.act.entity.ActStatus;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class ActRequestDto {
+
+    private String name;
+    private Long leadNo;
+    private ActStatus cls;
+    private String purpose;
+    private LocalDate actDate;
+    private String startTime;
+    private String endTime;
+    private String completeYn;
+    private String planContent;
+    private String actContent;
+
+}

--- a/src/main/java/beyond/samdasoo/act/dto/ActResponseDto.java
+++ b/src/main/java/beyond/samdasoo/act/dto/ActResponseDto.java
@@ -1,0 +1,38 @@
+package beyond.samdasoo.act.dto;
+
+import beyond.samdasoo.act.entity.Act;
+import beyond.samdasoo.act.entity.ActStatus;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class ActResponseDto {
+
+    private Long no;
+    private String name;
+    private Long leadNo;
+    private ActStatus cls;
+    private String purpose;
+    private LocalDate actDate;
+    private String startTime;
+    private String endTime;
+    private String completeYn;
+    private String planContent;
+    private String actContent;
+
+    public ActResponseDto(Act act) {
+        this.no = act.getNo();
+        this.name = act.getName();
+//        TODO: 영업기회 엔티티 완성 후 주석 해제 예정-ActResponseDto
+//        this.leadNo = act.getLeadNo().getNo();
+        this.cls = act.getCls();
+        this.purpose = act.getPurpose();
+        this.actDate = act.getActDate();
+        this.startTime = act.getStartTime();
+        this.endTime = act.getEndTime();
+        this.completeYn = act.getCompleteYn();
+        this.planContent = act.getPlanCont();
+        this.actContent = act.getActCont();
+    }
+}

--- a/src/main/java/beyond/samdasoo/act/entity/Act.java
+++ b/src/main/java/beyond/samdasoo/act/entity/Act.java
@@ -1,0 +1,56 @@
+package beyond.samdasoo.act.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name="tb_act")
+public class Act {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long no;
+
+//    TODO: 영업기회 엔티티 완성 후 주석 해제 예정-ENTITY
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "lead_no", nullable = false)
+//    private Lead leadNo;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "cls", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ActStatus cls;
+
+    @Column(name = "purpose", nullable = false)
+    private String purpose;
+
+    @Column(name = "act_date", nullable = false)
+    private LocalDate actDate;
+
+    @Column(name = "start_time")
+    private String startTime;
+
+    @Column(name = "end_time")
+    private String endTime;
+
+    @Column(name = "complete_yn")
+    private String completeYn;
+
+    @Column(name = "plan_cont")
+    private String planCont;
+
+    @Column(name = "act_cont")
+    private String actCont;
+
+}

--- a/src/main/java/beyond/samdasoo/act/entity/ActStatus.java
+++ b/src/main/java/beyond/samdasoo/act/entity/ActStatus.java
@@ -1,0 +1,11 @@
+package beyond.samdasoo.act.entity;
+
+public enum ActStatus {
+    MEETING,
+    PRODUCT_INTRO,
+    NEGOTIATION,
+    CONTRACT,
+    ESITIMATE,
+    PROPOSAL
+
+}

--- a/src/main/java/beyond/samdasoo/act/repository/ActRepository.java
+++ b/src/main/java/beyond/samdasoo/act/repository/ActRepository.java
@@ -1,0 +1,7 @@
+package beyond.samdasoo.act.repository;
+
+import beyond.samdasoo.act.entity.Act;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActRepository extends JpaRepository<Act, Long> {
+}

--- a/src/main/java/beyond/samdasoo/act/service/ActService.java
+++ b/src/main/java/beyond/samdasoo/act/service/ActService.java
@@ -1,0 +1,79 @@
+package beyond.samdasoo.act.service;
+
+import beyond.samdasoo.act.dto.ActRequestDto;
+import beyond.samdasoo.act.dto.ActResponseDto;
+import beyond.samdasoo.act.entity.Act;
+import beyond.samdasoo.act.repository.ActRepository;
+import beyond.samdasoo.lead.repository.LeadRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class ActService {
+
+    private final ActRepository actRepository;
+
+    private final LeadRepository leadRepository;
+
+    public ActService(ActRepository actRepository, LeadRepository leadRepository) {
+        this.actRepository = actRepository;
+        this.leadRepository = leadRepository;
+    }
+
+    private Act findActById(Long no) {
+        return actRepository.findById(no)
+                .orElseThrow(() -> new EntityNotFoundException("활동을 찾을 수 없습니다: " + no));
+    }
+
+//     TODO: 영업기회 엔티티 완성 후 주석 해제 예정
+//    private Lead findLeadById(Long no) {
+//        return leadRepository.findById(no)
+//                .orElseThrow(() -> new EntityNotFoundException("영업기회 조회 불가: " + no));
+//
+//    }
+
+    public ActResponseDto createAct(ActRequestDto actRequestDto) {
+
+        Act act = Act.builder()
+                .name(actRequestDto.getName())
+//                  TODO: 영업기회 엔티티 완성 후 주석 해제 예정-createAct
+//                .leadNo(findLeadById(actRequestDto.getLeadNo()))
+                .cls(actRequestDto.getCls())
+                .purpose(actRequestDto.getPurpose())
+                .actDate(actRequestDto.getActDate())
+                .startTime(actRequestDto.getStartTime())
+                .endTime(actRequestDto.getEndTime())
+                .completeYn(actRequestDto.getCompleteYn())
+                .planCont(actRequestDto.getPlanContent())
+                .actCont(actRequestDto.getActContent())
+                .build();
+
+        act = actRepository.save(act);
+        return new ActResponseDto(act);
+    }
+
+    @Transactional(readOnly = true)
+    public ActResponseDto getActById(Long no) {return new ActResponseDto(findActById(no));}
+
+    @Transactional
+    public void updateAct(Long no, ActRequestDto actRequestDto) {
+        Act act = findActById(no);
+
+        Optional.ofNullable(actRequestDto.getName()).ifPresent(act::setName);
+//        TODO: 영업기회 엔티티 완성 후 주석 해제 예정-updateAct
+//        act.setLeadNo(findLeadById(actRequestDto.getLeadNo()));
+        Optional.ofNullable(actRequestDto.getCls()).ifPresent(act::setCls);
+        Optional.ofNullable(actRequestDto.getPurpose()).ifPresent(act::setPurpose);
+        Optional.ofNullable(actRequestDto.getActDate()).ifPresent(act::setActDate);
+        Optional.ofNullable(actRequestDto.getStartTime()).ifPresent(act::setStartTime);
+        Optional.ofNullable(actRequestDto.getEndTime()).ifPresent(act::setEndTime);
+        Optional.ofNullable(actRequestDto.getCompleteYn()).ifPresent(act::setCompleteYn);
+        Optional.ofNullable(actRequestDto.getPlanContent()).ifPresent(act::setPlanCont);
+        Optional.ofNullable(actRequestDto.getActContent()).ifPresent(act::setActCont);
+    }
+
+    public void deleteAct(Long no) {actRepository.delete(findActById(no));}
+}

--- a/src/main/java/beyond/samdasoo/calendar/entity/Calendar.java
+++ b/src/main/java/beyond/samdasoo/calendar/entity/Calendar.java
@@ -1,4 +1,0 @@
-package beyond.samdasoo.calendar.entity;
-
-public class Calendar {
-}

--- a/src/main/java/beyond/samdasoo/plan/controller/PlanController.java
+++ b/src/main/java/beyond/samdasoo/plan/controller/PlanController.java
@@ -1,0 +1,43 @@
+package beyond.samdasoo.plan.controller;
+
+import beyond.samdasoo.plan.dto.PlanRequestDto;
+import beyond.samdasoo.plan.dto.PlanResponseDto;
+import beyond.samdasoo.plan.dto.PlanUpdateDto;
+import beyond.samdasoo.plan.service.PlanService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/plan")
+public class PlanController {
+    private final PlanService planService;
+
+    @Autowired
+    public PlanController(PlanService planService) { this.planService = planService; }
+
+
+    @PostMapping
+    public ResponseEntity<PlanResponseDto> createPlan(@RequestBody PlanRequestDto planRequestDto) {
+        PlanResponseDto responseDto = planService.createPlan(planRequestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/{no}")
+    public ResponseEntity<PlanResponseDto> getPlanById(@PathVariable("no") Long no) {
+        PlanResponseDto responseDto = planService.getPlanById(no);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @PatchMapping("/{no}")
+    public ResponseEntity<Void> patchUpdatePlan(@PathVariable("no") Long no, @RequestBody PlanUpdateDto planUpdateDto) {
+        planService.updatePlan(no, planUpdateDto);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{no}")
+    public ResponseEntity<Void> deletePlan(@PathVariable("no") Long no) {
+        planService.deletePlan(no);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/beyond/samdasoo/plan/dto/PlanRequestDto.java
+++ b/src/main/java/beyond/samdasoo/plan/dto/PlanRequestDto.java
@@ -1,0 +1,18 @@
+package beyond.samdasoo.plan.dto;
+
+import beyond.samdasoo.plan.entity.PlanStatus;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class PlanRequestDto {
+    private String personalYn;
+    private Long userNo;
+    private PlanStatus planCls;
+    private LocalDate planDate;
+    private String title;
+    private String startTime;
+    private String endTime;
+    private String content;
+}

--- a/src/main/java/beyond/samdasoo/plan/dto/PlanResponseDto.java
+++ b/src/main/java/beyond/samdasoo/plan/dto/PlanResponseDto.java
@@ -1,0 +1,33 @@
+package beyond.samdasoo.plan.dto;
+
+import beyond.samdasoo.plan.entity.Plan;
+import beyond.samdasoo.plan.entity.PlanStatus;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class PlanResponseDto {
+
+    private Long no ;
+    private Long userNo;
+    private String personalYn;
+    private PlanStatus planCls;
+    private LocalDate planDate;
+    private String title;
+    private String startTime;
+    private String endTime;
+    private String content;
+
+    public PlanResponseDto(Plan plan) {
+        this.no = plan.getNo();
+        this.userNo = plan.getUserNo().getId();
+        this.personalYn = plan.getPersonalYn();
+        this.planCls = plan.getPlanCls();
+        this.planDate = plan.getPlanDate();
+        this.title = plan.getTitle();
+        this.startTime = plan.getStartTime();
+        this.endTime = plan.getEndTime();
+        this.content = plan.getContent();
+    }
+}

--- a/src/main/java/beyond/samdasoo/plan/dto/PlanUpdateDto.java
+++ b/src/main/java/beyond/samdasoo/plan/dto/PlanUpdateDto.java
@@ -1,0 +1,17 @@
+package beyond.samdasoo.plan.dto;
+
+import beyond.samdasoo.plan.entity.PlanStatus;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class PlanUpdateDto {
+    private String personalYn;
+    private PlanStatus planCls;
+    private LocalDate planDate;
+    private String title;
+    private String startTime;
+    private String endTime;
+    private String content;
+}

--- a/src/main/java/beyond/samdasoo/plan/entity/Plan.java
+++ b/src/main/java/beyond/samdasoo/plan/entity/Plan.java
@@ -1,0 +1,51 @@
+package beyond.samdasoo.plan.entity;
+
+import beyond.samdasoo.common.entity.BaseEntity;
+import beyond.samdasoo.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Table(name="tb_plan")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Data
+public class Plan extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long no;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_no", nullable = false)
+    private User userNo;
+
+    @Column(name = "personal_yn", nullable = false, length = 1)
+    private String personalYn;
+
+    @Column(name = "plan_cls", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PlanStatus planCls;
+
+    @Column(name = "plan_date", nullable = false)
+    private LocalDate planDate;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "start_time")
+    private String startTime;
+
+    @Column(name = "end_time")
+    private String endTime;
+
+    @Column(name = "content")
+    private String content;
+
+}

--- a/src/main/java/beyond/samdasoo/plan/entity/PlanStatus.java
+++ b/src/main/java/beyond/samdasoo/plan/entity/PlanStatus.java
@@ -1,0 +1,9 @@
+package beyond.samdasoo.plan.entity;
+
+public enum PlanStatus {
+    PERSONAL,
+    COMPANY,
+    PROPOSAL,
+    ESTIMATE,
+    CONTRACT
+}

--- a/src/main/java/beyond/samdasoo/plan/repository/PlanRepository.java
+++ b/src/main/java/beyond/samdasoo/plan/repository/PlanRepository.java
@@ -1,0 +1,7 @@
+package beyond.samdasoo.plan.repository;
+
+import beyond.samdasoo.plan.entity.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+}

--- a/src/main/java/beyond/samdasoo/plan/service/PlanService.java
+++ b/src/main/java/beyond/samdasoo/plan/service/PlanService.java
@@ -1,0 +1,78 @@
+package beyond.samdasoo.plan.service;
+
+import beyond.samdasoo.member.entity.Member;
+import beyond.samdasoo.plan.dto.PlanRequestDto;
+import beyond.samdasoo.plan.dto.PlanResponseDto;
+import beyond.samdasoo.plan.dto.PlanUpdateDto;
+import beyond.samdasoo.plan.entity.Plan;
+import beyond.samdasoo.plan.repository.PlanRepository;
+import beyond.samdasoo.todo.dto.TodoResponseDto;
+import beyond.samdasoo.todo.entity.Todo;
+import beyond.samdasoo.user.entity.User;
+import beyond.samdasoo.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class PlanService {
+
+    private final PlanRepository planRepository;
+
+    private final UserRepository userRepository;
+
+    public PlanService(PlanRepository planRepository, UserRepository userRepository) {
+        this.planRepository = planRepository;
+        this.userRepository = userRepository;
+    }
+
+    private Plan findPlanById(Long id) {
+        return planRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("일정을 찾을 수 없습니다: " + id));
+    }
+
+    @Transactional
+    public PlanResponseDto createPlan(PlanRequestDto planRequestDto) {
+
+        User user = userRepository.findById(planRequestDto.getUserNo())
+                .orElseThrow(() -> new EntityNotFoundException("회원 ID 조회 불가: " + planRequestDto.getUserNo()));
+
+        Plan plan = Plan.builder()
+                .personalYn(planRequestDto.getPersonalYn())
+                .planCls(planRequestDto.getPlanCls())
+                .planDate(planRequestDto.getPlanDate())
+                .title(planRequestDto.getTitle())
+                .startTime(planRequestDto.getStartTime())
+                .endTime(planRequestDto.getEndTime())
+                .content(planRequestDto.getContent())
+                .userNo(user)
+                .build();
+
+        plan = planRepository.save(plan);
+        return new PlanResponseDto(plan);
+    }
+
+    @Transactional(readOnly = true)
+    public PlanResponseDto getPlanById(Long no) {
+        return new PlanResponseDto(findPlanById(no));
+    }
+
+    @Transactional
+    public void updatePlan(Long no, PlanUpdateDto planUpdateDto) {
+        Plan plan = findPlanById(no);
+
+        Optional.ofNullable(planUpdateDto.getPersonalYn()).ifPresent(plan::setPersonalYn);
+        Optional.ofNullable(planUpdateDto.getPlanCls()).ifPresent(plan::setPlanCls);
+        Optional.ofNullable(planUpdateDto.getPlanDate()).ifPresent(plan::setPlanDate);
+        Optional.ofNullable(planUpdateDto.getTitle()).ifPresent(plan::setTitle);
+        Optional.ofNullable(planUpdateDto.getStartTime()).ifPresent(plan::setStartTime);
+        Optional.ofNullable(planUpdateDto.getEndTime()).ifPresent(plan::setEndTime);
+        Optional.ofNullable(planUpdateDto.getContent()).ifPresent(plan::setContent);
+    }
+
+    public void deletePlan(Long no) {
+        planRepository.delete(findPlanById(no));
+    }
+}


### PR DESCRIPTION
## 📢 작업 내용 설명
- 영업활동 등록, 조회, 수정, 삭제 API 구현
- Calendar 폴더 삭제, Plan으로 구현 

<br>

<details>
  <summary> 영업활동 등록 </summary>

![image](https://github.com/user-attachments/assets/7b47a869-9a6c-4f1a-8d79-60bba9c576d2)

</details>
<details>
  <summary> 영업활동 조회 </summary>

![image](https://github.com/user-attachments/assets/a2d9bf3e-bfb2-406c-82ca-762cd3b23d22)

</details>
<details>
  <summary>  영업활동 수정 </summary>

![image](https://github.com/user-attachments/assets/f4c270cc-a8c0-4139-b946-6dd1cd4da445)

</details>
<details>
  <summary> 영업활동 삭제 </summary>

![image](https://github.com/user-attachments/assets/8cc147af-1c2b-42f7-87a8-f1b72f3fc292)

</details>

<br>

## #️⃣연관된  issue
close #8 

<br>



## ✅ 체크리스트
- [x] 새로운 기능 추가
- [x] 주석 추가 및 수정
- [x] 파일 혹은 폴더 삭제

<br>


## 📑To Reviewers

- 현재 TODO 태그로 주석처리 한 부분은 Lead 엔티티 구현 후에 주석해제 하면 될듯합니다.
