### PR TITLE
[Feat/#22] 응답 형식 추가, 유저 API 수정

### DIFF
--- a/src/main/java/beyond/samdasoo/common/exception/BaseException.java
+++ b/src/main/java/beyond/samdasoo/common/exception/BaseException.java
@@ -1,0 +1,15 @@
+package beyond.samdasoo.common.exception;
+
+import beyond.samdasoo.common.response.BaseResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException{
+
+    private BaseResponseStatus status;
+
+    public BaseException(BaseResponseStatus status) {
+        super(status.getMessage());
+        this.status = status;
+    }
+}

--- a/src/main/java/beyond/samdasoo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/beyond/samdasoo/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package beyond.samdasoo.common.exception;
+
+import beyond.samdasoo.common.response.BaseResponse;
+import beyond.samdasoo.common.response.BaseResponseStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BaseException.class)
+    public BaseResponse<BaseResponseStatus> baseExceptionHandle(BaseException e) {
+         log.warn("BaseException. error message: {}", e.getMessage());
+         return new BaseResponse<>(e.getStatus());
+     }
+
+    @ExceptionHandler(Exception.class)
+    public BaseResponse<BaseResponseStatus> exceptionHandle(Exception exception) {
+        log.error("Exception has occured. ", exception);
+        return new BaseResponse<>(BaseResponseStatus.UNEXPECTED_ERROR);
+    }
+}

--- a/src/main/java/beyond/samdasoo/common/response/BaseResponse.java
+++ b/src/main/java/beyond/samdasoo/common/response/BaseResponse.java
@@ -1,0 +1,35 @@
+package beyond.samdasoo.common.response;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static beyond.samdasoo.common.response.BaseResponseStatus.SUCCESS;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class BaseResponse<T> {
+
+    private final Boolean isSuccess;
+    private final String message;
+    private final int code;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+    // 성공
+    public BaseResponse(T result) {
+        this.isSuccess = SUCCESS.isSuccess();
+        this.message = SUCCESS.getMessage();
+        this.code = SUCCESS.getCode();
+        this.result = result;
+    }
+
+    // 실패
+    public BaseResponse(BaseResponseStatus status) {
+        this.isSuccess = status.isSuccess();
+        this.message = status.getMessage();
+        this.code = status.getCode();
+    }
+}

--- a/src/main/java/beyond/samdasoo/common/response/BaseResponseStatus.java
+++ b/src/main/java/beyond/samdasoo/common/response/BaseResponseStatus.java
@@ -1,0 +1,42 @@
+package beyond.samdasoo.common.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum BaseResponseStatus {
+
+    /**
+     * 200 : 요청 성공
+     */
+    SUCCESS(true, HttpStatus.OK.value(), "요청에 성공하였습니다"),
+
+    /**
+     * 400 : Request, Response 오류
+     */
+
+    /**
+     * user 관련
+     */
+
+    EMAIL_ALREADY_EXIST(false,HttpStatus.BAD_REQUEST.value(), "이미 사용중인 이메일입니다"),
+    EMAIL_OR_PWD_NOT_FOUND(false,HttpStatus.BAD_REQUEST.value(), "이메일/비밀번호를 확인해주세요"),
+
+
+    /**
+     * 500 :  Database, Server 오류
+     */
+
+    UNEXPECTED_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "예상치 못한 에러가 발생했습니다");
+
+
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+
+    BaseResponseStatus(boolean isSuccess, int code, String message) {
+        this.isSuccess = isSuccess;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/beyond/samdasoo/common/response/BaseResponseStatus.java
+++ b/src/main/java/beyond/samdasoo/common/response/BaseResponseStatus.java
@@ -21,6 +21,7 @@ public enum BaseResponseStatus {
 
     EMAIL_ALREADY_EXIST(false,HttpStatus.BAD_REQUEST.value(), "이미 사용중인 이메일입니다"),
     EMAIL_OR_PWD_NOT_FOUND(false,HttpStatus.BAD_REQUEST.value(), "이메일/비밀번호를 확인해주세요"),
+    USER_NOT_EXIST(false, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 회원입니다"),
 
 
     /**

--- a/src/main/java/beyond/samdasoo/member/entity/Member.java
+++ b/src/main/java/beyond/samdasoo/member/entity/Member.java
@@ -5,7 +5,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
 
+@Getter
 @Entity
 public class Member extends BaseEntity {
 

--- a/src/main/java/beyond/samdasoo/user/controller/UserController.java
+++ b/src/main/java/beyond/samdasoo/user/controller/UserController.java
@@ -2,14 +2,15 @@ package beyond.samdasoo.user.controller;
 import beyond.samdasoo.common.response.BaseResponse;
 import beyond.samdasoo.user.dto.JoinUserReq;
 import beyond.samdasoo.user.dto.LoginUserReq;
+import beyond.samdasoo.user.dto.UserDto;
 import beyond.samdasoo.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(name="User APIs",description = "유저 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
 @RestController
@@ -21,6 +22,7 @@ public class UserController {
     /**
      * 회원가입 API
      */
+    @Operation(summary = "회원가입",description = "유저 정보를 받아 회원가입을 진행한다")
     @PostMapping("/join")
     public BaseResponse<String> join(@RequestBody @Valid JoinUserReq joinUserReq){
           userService.join(joinUserReq);
@@ -30,6 +32,7 @@ public class UserController {
     /**
      * 로그인 API
      */
+    @Operation(summary = "로그인", description = "이메일과 비밀번호를 받아 로그인을 진행한다.")
     @PostMapping("/login")
     public BaseResponse<String> login(@RequestBody @Valid LoginUserReq loginUserReq){
 
@@ -38,6 +41,17 @@ public class UserController {
             return new BaseResponse<>("로그인을 완료했습니다");
     }
 
+    /**
+     * 유저 정보 조회 API
+     */
+    @Operation(summary = "유저 조회", description = "유저 정보를 조회한다.")
+    @GetMapping("/{id}")
+    public BaseResponse<UserDto> getUser(@PathVariable(name = "id") Long userId){
+
+        UserDto result = userService.getUser(userId);
+
+        return new BaseResponse<>(result);
+    }
 
 
 

--- a/src/main/java/beyond/samdasoo/user/controller/UserController.java
+++ b/src/main/java/beyond/samdasoo/user/controller/UserController.java
@@ -1,4 +1,5 @@
 package beyond.samdasoo.user.controller;
+import beyond.samdasoo.common.response.BaseResponse;
 import beyond.samdasoo.user.dto.JoinUserReq;
 import beyond.samdasoo.user.dto.LoginUserReq;
 import beyond.samdasoo.user.service.UserService;
@@ -21,21 +22,22 @@ public class UserController {
      * 회원가입 API
      */
     @PostMapping("/join")
-    public String join(@RequestBody @Valid JoinUserReq joinUserReq){
+    public BaseResponse<String> join(@RequestBody @Valid JoinUserReq joinUserReq){
           userService.join(joinUserReq);
-          return "회원가입 완료";
+          return new BaseResponse<>("회원가입을 완료했습니다");
     }
 
     /**
      * 로그인 API
      */
     @PostMapping("/login")
-    public String login(@RequestBody @Valid LoginUserReq loginUserReq){
+    public BaseResponse<String> login(@RequestBody @Valid LoginUserReq loginUserReq){
 
             userService.login(loginUserReq);
 
-            return "로그인 완료";
+            return new BaseResponse<>("로그인을 완료했습니다");
     }
+
 
 
 

--- a/src/main/java/beyond/samdasoo/user/dto/UserDto.java
+++ b/src/main/java/beyond/samdasoo/user/dto/UserDto.java
@@ -1,0 +1,12 @@
+package beyond.samdasoo.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserDto {
+
+    private String email;
+    private String name;
+}

--- a/src/main/java/beyond/samdasoo/user/service/UserService.java
+++ b/src/main/java/beyond/samdasoo/user/service/UserService.java
@@ -3,6 +3,7 @@ package beyond.samdasoo.user.service;
 import beyond.samdasoo.common.exception.BaseException;
 import beyond.samdasoo.user.dto.JoinUserReq;
 import beyond.samdasoo.user.dto.LoginUserReq;
+import beyond.samdasoo.user.dto.UserDto;
 import beyond.samdasoo.user.entity.User;
 import beyond.samdasoo.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
-import static beyond.samdasoo.common.response.BaseResponseStatus.EMAIL_ALREADY_EXIST;
-import static beyond.samdasoo.common.response.BaseResponseStatus.EMAIL_OR_PWD_NOT_FOUND;
+import static beyond.samdasoo.common.response.BaseResponseStatus.*;
 
 @RequiredArgsConstructor
 @Service
@@ -46,5 +46,12 @@ public class UserService {
         }
 
         // todo : jwt 토큰 발급
+    }
+
+    public UserDto getUser(Long userId) {
+
+        User findUser = userRepository.findById(userId).orElseThrow(()->new BaseException(USER_NOT_EXIST));
+
+        return new UserDto(findUser.getName(), findUser.getEmail());
     }
 }


### PR DESCRIPTION
## 📢 작업 내용 설명
- 요청 성공시 응답 , 요청 실패시 예외처리 응답 형식 추가
- 유저 API에 추가된 형식 적용

<br>

<details>
  <summary> 회원가입 성공</summary>
<img width="447" alt="회원가입 성공" src="https://github.com/user-attachments/assets/c95f4991-a994-4011-a5f2-0195c6cab857">

</details>

<details>
  <summary> 회원가입 실패 (예외처리) </summary>
<img width="334" alt="회원가입시 이미 등록한 이메일" src="https://github.com/user-attachments/assets/0b038e7d-ae82-44e1-935d-5533da1d4a6a">

</details>


<details>
  <summary> 로그인 성공 </summary>
<img width="402" alt="로그인 성공" src="https://github.com/user-attachments/assets/935dd5d8-3527-4e35-a62d-5bb4757a9235">

</details>

<details>
  <summary> 로그인 실패 (예외처리) </summary>
<img width="385" alt="로그인 실패" src="https://github.com/user-attachments/assets/1e1348be-65af-4865-beaa-2ec9021a7f89">
</details>

<details>
  <summary> 유저 조회 (성공/실패)</summary>
<img width="397" alt="유저 조회" src="https://github.com/user-attachments/assets/eefe48d0-4d8b-4e58-93a1-51d31aab647b">
<img width="325" alt="유저 조회 실패" src="https://github.com/user-attachments/assets/d4ca5e52-815d-4789-94d1-4a23ab8a476d">

</details>
<br>

## #️⃣연관된  issue
#22 

<br>



## ✅ 체크리스트
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 코드 중간 통합

<br>


## 📑To Reviewers
- controller 에서 응답할때 형식을 BaseResponse 로 통일시키면 됩니다.
<img width="877" alt="스크린샷 2024-09-29 오후 2 59 14" src="https://github.com/user-attachments/assets/1b0e2084-0e93-43f1-a9f0-56e4c334d9a8">

- 개발자가 처리할 수 있는 예외인경우 BaseException 을 던지면 됩니다. 
<img width="1081" alt="스크린샷 2024-09-29 오후 2 59 55" src="https://github.com/user-attachments/assets/39431ab6-1ae6-48b1-8b5b-2ead142362f8">
