### PR TITLE
[Feat/#47] 일정 관련 할 일 조회 API 추가 

### DIFF
--- a/src/main/java/beyond/samdasoo/act/controller/ActController.java
+++ b/src/main/java/beyond/samdasoo/act/controller/ActController.java
@@ -13,8 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static beyond.samdasoo.common.response.BaseResponseStatus.ACT_NOT_EXIST;
-
 @RestController
 @RequestMapping("/api/acts")
 @Tag(name="Act APIs", description = "영업활동 API")

--- a/src/main/java/beyond/samdasoo/plan/controller/PlanController.java
+++ b/src/main/java/beyond/samdasoo/plan/controller/PlanController.java
@@ -5,6 +5,7 @@ import beyond.samdasoo.common.response.BaseResponse;
 import beyond.samdasoo.common.response.BaseResponseStatus;
 import beyond.samdasoo.plan.dto.PlanRequestDto;
 import beyond.samdasoo.plan.dto.PlanResponseDto;
+import beyond.samdasoo.plan.dto.PlanTodoResponseDto;
 import beyond.samdasoo.plan.dto.PlanUpdateDto;
 import beyond.samdasoo.plan.service.PlanService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/plans")
@@ -37,6 +40,18 @@ public class PlanController {
         try{
             PlanResponseDto responseDto = planService.getPlanById(no);
             return ResponseEntity.ok(new BaseResponse<>(responseDto));
+        }catch (BaseException ex) {
+            BaseResponseStatus status = ex.getStatus();
+            return new ResponseEntity<>(new BaseResponse<>(status), HttpStatus.valueOf(status.getCode()));
+        }
+    }
+
+    @GetMapping("/{no}/details")
+    @Operation(summary = "일정 및 할 일 조회", description = "특정 일정 및 할 일 조회")
+    public ResponseEntity<BaseResponse<List<PlanTodoResponseDto>>> getPlansWithTodo(@PathVariable("no") Long no) {
+        try{
+            List<PlanTodoResponseDto> plans = planService.getPlansWithTodo(no);
+            return ResponseEntity.ok(new BaseResponse<>(plans));
         }catch (BaseException ex) {
             BaseResponseStatus status = ex.getStatus();
             return new ResponseEntity<>(new BaseResponse<>(status), HttpStatus.valueOf(status.getCode()));

--- a/src/main/java/beyond/samdasoo/plan/dto/PlanResponseDto.java
+++ b/src/main/java/beyond/samdasoo/plan/dto/PlanResponseDto.java
@@ -20,7 +20,7 @@ public class PlanResponseDto {
     private String content;
 
     public PlanResponseDto(Plan plan) {
-        this.planNo = plan.getPlanNo();
+        this.planNo = plan.getNo();
         this.userNo = plan.getUser().getId();
         this.personalYn = plan.getPersonalYn();
         this.planCls = plan.getPlanCls();

--- a/src/main/java/beyond/samdasoo/plan/dto/PlanTodoResponseDto.java
+++ b/src/main/java/beyond/samdasoo/plan/dto/PlanTodoResponseDto.java
@@ -1,0 +1,16 @@
+package beyond.samdasoo.plan.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class PlanTodoResponseDto {
+
+    private Long planNo;
+    private LocalDate planDate;
+    private List<String> todoTitles;
+}

--- a/src/main/java/beyond/samdasoo/plan/entity/Plan.java
+++ b/src/main/java/beyond/samdasoo/plan/entity/Plan.java
@@ -1,6 +1,7 @@
 package beyond.samdasoo.plan.entity;
 
 import beyond.samdasoo.common.entity.BaseEntity;
+import beyond.samdasoo.todo.entity.Todo;
 import beyond.samdasoo.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -9,22 +10,26 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
-@Table(name="tb_plan")
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-@Entity
 @Data
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name="tb_plan")
 public class Plan extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long planNo;
+    private Long no;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_no", nullable = false)
     private User user;
+
+    @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL)
+    private List<Todo> todos;
 
     @Column(name = "personal_yn", nullable = false, length = 1)
     private String personalYn;

--- a/src/main/java/beyond/samdasoo/plan/service/PlanService.java
+++ b/src/main/java/beyond/samdasoo/plan/service/PlanService.java
@@ -3,15 +3,21 @@ package beyond.samdasoo.plan.service;
 import beyond.samdasoo.common.exception.BaseException;
 import beyond.samdasoo.plan.dto.PlanRequestDto;
 import beyond.samdasoo.plan.dto.PlanResponseDto;
+import beyond.samdasoo.plan.dto.PlanTodoResponseDto;
 import beyond.samdasoo.plan.dto.PlanUpdateDto;
 import beyond.samdasoo.plan.entity.Plan;
 import beyond.samdasoo.plan.repository.PlanRepository;
+import beyond.samdasoo.todo.entity.Todo;
+import beyond.samdasoo.todo.repository.TodoRepository;
 import beyond.samdasoo.user.entity.User;
 import beyond.samdasoo.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static beyond.samdasoo.common.response.BaseResponseStatus.PLAN_NOT_EXIST;
 import static beyond.samdasoo.common.response.BaseResponseStatus.USER_NOT_EXIST;
@@ -20,17 +26,40 @@ import static beyond.samdasoo.common.response.BaseResponseStatus.USER_NOT_EXIST;
 public class PlanService {
 
     private final PlanRepository planRepository;
-
     private final UserRepository userRepository;
+    private final TodoRepository todoRepository;
 
-    public PlanService(PlanRepository planRepository, UserRepository userRepository) {
+    public PlanService(PlanRepository planRepository, UserRepository userRepository, TodoRepository todoRepository) {
         this.planRepository = planRepository;
         this.userRepository = userRepository;
+        this.todoRepository = todoRepository;
     }
 
     private Plan findPlanById(Long id) {
         return planRepository.findById(id)
                 .orElseThrow(() -> new BaseException(PLAN_NOT_EXIST));
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlanTodoResponseDto> getPlansWithTodo(Long no) {
+
+        Optional<Plan> optionalPlan = planRepository.findById(no);
+
+        if (optionalPlan.isEmpty()) {
+            throw new BaseException(PLAN_NOT_EXIST);
+        }
+
+        Plan plan = optionalPlan.get();
+        List<PlanTodoResponseDto> result = new ArrayList<>();
+
+        if (!plan.getTodos().isEmpty()) {
+            List<String> todoTitles = plan.getTodos().stream()
+                    .map(Todo::getTitle)
+                    .collect(Collectors.toList());
+            result.add(new PlanTodoResponseDto(plan.getNo(), plan.getPlanDate(), todoTitles));
+        }
+
+        return result;
     }
 
     @Transactional
@@ -49,15 +78,12 @@ public class PlanService {
                 .content(planRequestDto.getContent())
                 .user(user)
                 .build();
-
         plan = planRepository.save(plan);
         return new PlanResponseDto(plan);
     }
 
     @Transactional(readOnly = true)
-    public PlanResponseDto getPlanById(Long no) {
-        return new PlanResponseDto(findPlanById(no));
-    }
+    public PlanResponseDto getPlanById(Long no) { return new PlanResponseDto(findPlanById(no)); }
 
     @Transactional
     public void updatePlan(Long no, PlanUpdateDto planUpdateDto) {

--- a/src/main/java/beyond/samdasoo/todo/controller/TodoController.java
+++ b/src/main/java/beyond/samdasoo/todo/controller/TodoController.java
@@ -3,7 +3,6 @@ package beyond.samdasoo.todo.controller;
 import beyond.samdasoo.common.exception.BaseException;
 import beyond.samdasoo.common.response.BaseResponse;
 import beyond.samdasoo.common.response.BaseResponseStatus;
-import beyond.samdasoo.plan.dto.PlanResponseDto;
 import beyond.samdasoo.todo.dto.TodoRequestDto;
 import beyond.samdasoo.todo.dto.TodoResponseDto;
 import beyond.samdasoo.todo.dto.TodoUpdateDto;
@@ -14,8 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import static beyond.samdasoo.common.response.BaseResponseStatus.TODO_NOT_EXIST;
 
 @RestController
 @RequestMapping("/api/todos")

--- a/src/main/java/beyond/samdasoo/todo/dto/TodoRequestDto.java
+++ b/src/main/java/beyond/samdasoo/todo/dto/TodoRequestDto.java
@@ -32,5 +32,8 @@ public class TodoRequestDto {
 
     @Schema(description = "사용자 번호", defaultValue = "1")
     private Long userNo;
+    
+    @Schema(description = "일정 번호", defaultValue = "1")
+    private Long planNo;
 
 }

--- a/src/main/java/beyond/samdasoo/todo/dto/TodoResponseDto.java
+++ b/src/main/java/beyond/samdasoo/todo/dto/TodoResponseDto.java
@@ -8,8 +8,9 @@ import java.time.LocalDate;
 
 @Data
 public class TodoResponseDto {
-
     private Long todoNo;
+    private Long userNo;
+    private Long planNo;
     private String title;
     private String todoCls;
     private String priority;
@@ -17,10 +18,11 @@ public class TodoResponseDto {
     private TodoStatus status;
     private String privateYn;
     private String content;
-    private Long userNo;
 
     public TodoResponseDto(Todo todo) {
-        this.todoNo = todo.getTodoNo();
+        this.todoNo = todo.getNo();
+        this.userNo = todo.getUser().getId();
+        this.planNo = todo.getPlan() != null ? todo.getPlan().getNo() : null;
         this.title = todo.getTitle();
         this.todoCls = todo.getTodoCls();
         this.priority = todo.getPriority();
@@ -28,7 +30,6 @@ public class TodoResponseDto {
         this.status = todo.getStatus();
         this.privateYn = todo.getPrivateYn();
         this.content = todo.getContent();
-        this.userNo = todo.getUser().getId();
     }
 
 }

--- a/src/main/java/beyond/samdasoo/todo/entity/Todo.java
+++ b/src/main/java/beyond/samdasoo/todo/entity/Todo.java
@@ -21,11 +21,15 @@ public class Todo extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long todoNo;
+    private Long no;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_no", nullable=false)
     private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_no")
+    private Plan plan;
 
     @Column(name = "title", nullable = false)
     private String title;

--- a/src/main/java/beyond/samdasoo/todo/service/TodoService.java
+++ b/src/main/java/beyond/samdasoo/todo/service/TodoService.java
@@ -1,6 +1,8 @@
 package beyond.samdasoo.todo.service;
 
 import beyond.samdasoo.common.exception.BaseException;
+import beyond.samdasoo.plan.entity.Plan;
+import beyond.samdasoo.plan.repository.PlanRepository;
 import beyond.samdasoo.todo.dto.TodoRequestDto;
 import beyond.samdasoo.todo.dto.TodoResponseDto;
 import beyond.samdasoo.todo.dto.TodoUpdateDto;
@@ -14,20 +16,20 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-import static beyond.samdasoo.common.response.BaseResponseStatus.TODO_NOT_EXIST;
-import static beyond.samdasoo.common.response.BaseResponseStatus.USER_NOT_EXIST;
+import static beyond.samdasoo.common.response.BaseResponseStatus.*;
 
 @Service
 public class TodoService {
 
     private final TodoRepository todoRepository;
-
     private final UserRepository userRepository;
+    private final PlanRepository planRepository;
 
     @Autowired
-    public TodoService(TodoRepository todoRepository, UserRepository userRepository) {
+    public TodoService(TodoRepository todoRepository, UserRepository userRepository, PlanRepository planRepository) {
         this.todoRepository = todoRepository;
         this.userRepository = userRepository;
+        this.planRepository = planRepository;
     }
 
     private Todo findById(Long no){
@@ -41,6 +43,9 @@ public class TodoService {
         User user = userRepository.findById(todoRequestDto.getUserNo())
                 .orElseThrow(() -> new BaseException(USER_NOT_EXIST));
 
+        Plan plan = todoRequestDto.getPlanNo() != null ? planRepository.findById(todoRequestDto.getPlanNo())
+                .orElseThrow(() -> new BaseException(PLAN_NOT_EXIST)) : null;
+
         Todo todo = Todo.builder()
                 .title(todoRequestDto.getTitle())
                 .todoCls(todoRequestDto.getTodoCls())
@@ -50,6 +55,7 @@ public class TodoService {
                 .privateYn(todoRequestDto.getPrivateYn())
                 .content(todoRequestDto.getContent())
                 .user(user)
+                .plan(plan)
                 .build();
 
         todo = todoRepository.save(todo);


### PR DESCRIPTION
## 📢 작업 내용 설명
- Plan-Todo 연관관계 매핑
- 필요한 Dto 추가
- 일정 관련 할 일이 존재할 때만 동작하도록 로직 구현
- plan,todo 변수명 변경
- 불필요한 import문 제거
<br>

<details>
  <summary> 조회 결과 </summary>

![image](https://github.com/user-attachments/assets/44782dae-1889-4221-98e6-fe6e640adee9)

</details>

<br>

## #️⃣연관된  issue
#47

<br>

## ✅ 체크리스트
- [x] 새로운 기능 추가
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 주석 추가 및 수정

<br>

