### PR TITLE
[Feat/#57] 영업활동, 일정, 할 일 리스트 조회 API 추가

### DIFF
--- a/src/main/java/beyond/samdasoo/act/controller/ActController.java
+++ b/src/main/java/beyond/samdasoo/act/controller/ActController.java
@@ -6,12 +6,15 @@ import beyond.samdasoo.act.service.ActService;
 import beyond.samdasoo.common.exception.BaseException;
 import beyond.samdasoo.common.response.BaseResponse;
 import beyond.samdasoo.common.response.BaseResponseStatus;
+import beyond.samdasoo.todo.dto.TodoResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/acts")
@@ -36,6 +39,18 @@ public class ActController {
         try {
             ActResponseDto responseDto = actService.getActById(no);
             return ResponseEntity.ok(new BaseResponse<>(responseDto));
+        } catch (BaseException ex) {
+            BaseResponseStatus status = ex.getStatus();
+            return new ResponseEntity<>(new BaseResponse<>(status), HttpStatus.valueOf(status.getCode()));
+        }
+    }
+
+    @GetMapping
+    @Operation(summary = "전체 영업활동 조회", description = "모든 영업활동 조회")
+    public ResponseEntity<BaseResponse<List<ActResponseDto>>> getAllActs() {
+        try {
+            List<ActResponseDto> acts = actService.getAllActs();
+            return ResponseEntity.ok(new BaseResponse<>(acts));
         } catch (BaseException ex) {
             BaseResponseStatus status = ex.getStatus();
             return new ResponseEntity<>(new BaseResponse<>(status), HttpStatus.valueOf(status.getCode()));

--- a/src/main/java/beyond/samdasoo/act/service/ActService.java
+++ b/src/main/java/beyond/samdasoo/act/service/ActService.java
@@ -6,10 +6,13 @@ import beyond.samdasoo.act.entity.Act;
 import beyond.samdasoo.act.repository.ActRepository;
 import beyond.samdasoo.common.exception.BaseException;
 import beyond.samdasoo.lead.repository.LeadRepository;
+import beyond.samdasoo.todo.dto.TodoResponseDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static beyond.samdasoo.common.response.BaseResponseStatus.ACT_NOT_EXIST;
 
@@ -25,9 +28,15 @@ public class ActService {
         this.leadRepository = leadRepository;
     }
 
-    private Act findActById(Long no) {
+    public Act findActById(Long no) {
         return actRepository.findById(no)
                 .orElseThrow(() -> new BaseException(ACT_NOT_EXIST));
+    }
+
+    public List<ActResponseDto> getAllActs() throws BaseException {
+        return actRepository.findAll().stream()
+                .map(act -> new ActResponseDto(act))
+                .collect(Collectors.toList());
     }
 
 //     TODO: 영업기회 엔티티 완성 후 주석 해제 예정

--- a/src/main/java/beyond/samdasoo/plan/controller/PlanController.java
+++ b/src/main/java/beyond/samdasoo/plan/controller/PlanController.java
@@ -46,6 +46,18 @@ public class PlanController {
         }
     }
 
+    @GetMapping
+    @Operation(summary = "전체 일정 조회", description = "모든 일정 조회")
+    public ResponseEntity<BaseResponse<List<PlanResponseDto>>> getAllPlans() {
+        try {
+            List<PlanResponseDto> plans = planService.getAllPlans();
+            return ResponseEntity.ok(new BaseResponse<>(plans));
+        } catch (BaseException ex) {
+            BaseResponseStatus status = ex.getStatus();
+            return new ResponseEntity<>(new BaseResponse<>(status), HttpStatus.valueOf(status.getCode()));
+        }
+    }
+
     @GetMapping("/{no}/details")
     @Operation(summary = "일정 및 할 일 조회", description = "특정 일정 및 할 일 조회")
     public ResponseEntity<BaseResponse<List<PlanTodoResponseDto>>> getPlansWithTodo(@PathVariable("no") Long no) {

--- a/src/main/java/beyond/samdasoo/todo/controller/TodoController.java
+++ b/src/main/java/beyond/samdasoo/todo/controller/TodoController.java
@@ -3,6 +3,7 @@ package beyond.samdasoo.todo.controller;
 import beyond.samdasoo.common.exception.BaseException;
 import beyond.samdasoo.common.response.BaseResponse;
 import beyond.samdasoo.common.response.BaseResponseStatus;
+import beyond.samdasoo.plan.dto.PlanResponseDto;
 import beyond.samdasoo.todo.dto.TodoRequestDto;
 import beyond.samdasoo.todo.dto.TodoResponseDto;
 import beyond.samdasoo.todo.dto.TodoUpdateDto;
@@ -13,6 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/todos")
@@ -39,6 +42,18 @@ public class TodoController {
             TodoResponseDto responseDto = todoService.getTodoById(no);
             return ResponseEntity.ok(new BaseResponse<>(responseDto));
         }catch (BaseException ex) {
+            BaseResponseStatus status = ex.getStatus();
+            return new ResponseEntity<>(new BaseResponse<>(status), HttpStatus.valueOf(status.getCode()));
+        }
+    }
+
+    @GetMapping
+    @Operation(summary = "전체 할 일 조회", description = "모든 할 일 조회")
+    public ResponseEntity<BaseResponse<List<TodoResponseDto>>> getAllTodos() {
+        try {
+            List<TodoResponseDto> todos = todoService.getAllTodos();
+            return ResponseEntity.ok(new BaseResponse<>(todos));
+        } catch (BaseException ex) {
             BaseResponseStatus status = ex.getStatus();
             return new ResponseEntity<>(new BaseResponse<>(status), HttpStatus.valueOf(status.getCode()));
         }

--- a/src/main/java/beyond/samdasoo/todo/service/TodoService.java
+++ b/src/main/java/beyond/samdasoo/todo/service/TodoService.java
@@ -1,6 +1,7 @@
 package beyond.samdasoo.todo.service;
 
 import beyond.samdasoo.common.exception.BaseException;
+import beyond.samdasoo.plan.dto.PlanResponseDto;
 import beyond.samdasoo.plan.entity.Plan;
 import beyond.samdasoo.plan.repository.PlanRepository;
 import beyond.samdasoo.todo.dto.TodoRequestDto;
@@ -14,7 +15,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static beyond.samdasoo.common.response.BaseResponseStatus.*;
 
@@ -35,6 +38,12 @@ public class TodoService {
     private Todo findById(Long no){
         return todoRepository.findById(no)
                 .orElseThrow(() -> new BaseException(TODO_NOT_EXIST));
+    }
+
+    public List<TodoResponseDto> getAllTodos() throws BaseException {
+        return todoRepository.findAll().stream()
+                .map(todo -> new TodoResponseDto(todo))
+                .collect(Collectors.toList());
     }
 
     @Transactional


### PR DESCRIPTION
## 📢 작업 내용 설명
- 영업활동, 일정, 할 일 리스트 조회 API 추가

<br>

<details>
  <summary> 영업활동 </summary>

![image](https://github.com/user-attachments/assets/466351ee-bb81-4f2d-8bd4-11667edd0d0a)

</details>

<details>
  <summary> 할 일 </summary>

![image](https://github.com/user-attachments/assets/23fec5fb-2847-4093-a9bb-6b81f876474f)

</details>


<details>
  <summary> 일정 </summary>

![image](https://github.com/user-attachments/assets/8f0810a5-fdcb-456f-82d4-d6056a0a7857)
</details>

<br>

## #️⃣연관된  issue
close #57

<br>



## ✅ 체크리스트
- [ ] 새로운 기능 추가

<br>
