### PR TITLE
[Feat/#85] 메인 인증코드 전송

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
     implementation group: 'com.lowagie', name: 'itext', version: '2.1.7'
     implementation group: 'net.sf.jasperreports', name: 'jasperreports', version: '6.20.0'
     implementation files('src/main/resources/lib/font-extension.jar')
+
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/beyond/samdasoo/common/email/CertificationNumber.java
+++ b/src/main/java/beyond/samdasoo/common/email/CertificationNumber.java
@@ -1,0 +1,17 @@
+package beyond.samdasoo.common.email;
+
+public class CertificationNumber {
+
+    public static String getCertificationNumber() {
+
+        String certificationNumber = "";
+
+        for (int count = 0; count < 6; count++) {
+            certificationNumber += (int) (Math.random() * 10); // 0 ~ 9
+        }
+
+        return certificationNumber;
+
+    }
+
+}

--- a/src/main/java/beyond/samdasoo/common/email/EmailProvider.java
+++ b/src/main/java/beyond/samdasoo/common/email/EmailProvider.java
@@ -1,0 +1,54 @@
+package beyond.samdasoo.common.email;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailProvider {
+
+    private final JavaMailSender javaMailSender;
+
+    private final String SIGNUP_TITLE = "회원가입 인증 메일";
+    private final String CHANGE_PASSWORD_TITLE = "비밀번호 재설정 메일";
+
+    public boolean sendCertificationMail(String email, String certificationNumber) {
+
+        try {
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper messageHelper = new MimeMessageHelper(message, true);
+
+            String htmlContent = getCertificationMessage(certificationNumber);
+
+            messageHelper.setTo(email);
+            messageHelper.setSubject(SIGNUP_TITLE);
+            messageHelper.setText(htmlContent,true);
+
+            javaMailSender.send(message);
+
+        } catch (MessagingException e) {
+            e.printStackTrace();
+            return false;
+        }
+        return true;
+
+    }
+
+    public boolean sendFindPasswordMail(){
+        // todo : 진행 예정
+        return true;
+    }
+
+    private String getCertificationMessage(String certificationNumber){
+        String message = "";
+        message +="<p>안녕하세요. SalesBoost 입니다. </p>";
+        message +="<p>본인 확인을 위하여 아래의 인증 번호를 확인후, 회원가입 창에 입력해 주세요. </p>";
+        message +="<p>해당 인증 코드의 유효시간은 <strong>5</strong> 분입니다.</p>";
+        message+="<p>인증코드 : <strong style='font-size:17px;'>"+certificationNumber+"</strong></p>";
+        return message;
+    }
+}

--- a/src/main/java/beyond/samdasoo/user/dto/SendEmailCodeReq.java
+++ b/src/main/java/beyond/samdasoo/user/dto/SendEmailCodeReq.java
@@ -1,0 +1,2 @@
+package beyond.samdasoo.user.dto;public class SendEmailCodeReq {
+}


### PR DESCRIPTION
## 📢 작업 내용 설명
> 요청한 메일로 인증코드를 전송

<br>

<details>
  <summary> postman 사용 예시 </summary>

![스크린샷 2024-10-17 오전 12 48 07](https://github.com/user-attachments/assets/b55f5b8b-5a0a-465e-bb49-2d00e527b458)

![스크린샷 2024-10-17 오전 12 48 19](https://github.com/user-attachments/assets/d03cbe55-364b-4186-8edf-1b52cacb0d58)

</details>

<br>

## #️⃣연관된  issue
#85

<br>



## ✅ 체크리스트
- [x] 새로운 기능 추가

<br>


## 📑To Reviewers (선택)

- 아직 redis 연결이나 프론트 구현 x
