### PR TITLE
[Feat/#106] 메인페이지 고객, 잠재고객, 영업기회, 영업활동 통계 api 추가

### DIFF
--- a/src/main/java/beyond/samdasoo/act/controller/ActController.java
+++ b/src/main/java/beyond/samdasoo/act/controller/ActController.java
@@ -2,7 +2,9 @@ package beyond.samdasoo.act.controller;
 
 import beyond.samdasoo.act.dto.ActRequestDto;
 import beyond.samdasoo.act.dto.ActResponseDto;
+import beyond.samdasoo.act.dto.ActStatusDto;
 import beyond.samdasoo.act.service.ActService;
+import beyond.samdasoo.common.dto.SearchCond;
 import beyond.samdasoo.common.exception.BaseException;
 import beyond.samdasoo.common.response.BaseResponse;
 import beyond.samdasoo.common.response.BaseResponseStatus;
@@ -117,4 +119,9 @@ public class ActController {
         }
     }
 
+    @PostMapping("/status/main")
+    public ResponseEntity<ActStatusDto> getActStatus(@RequestBody SearchCond searchCond) {
+        ActStatusDto actStatus = actService.getActStatus(searchCond);
+        return ResponseEntity.ok(actStatus);
+    }
 }

--- a/src/main/java/beyond/samdasoo/act/dto/ActStatusDto.java
+++ b/src/main/java/beyond/samdasoo/act/dto/ActStatusDto.java
@@ -1,0 +1,13 @@
+package beyond.samdasoo.act.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ActStatusDto {
+    private long planCount;
+    private long completeCount;
+    private long completePercent;
+}

--- a/src/main/java/beyond/samdasoo/act/repository/ActRepository.java
+++ b/src/main/java/beyond/samdasoo/act/repository/ActRepository.java
@@ -3,5 +3,5 @@ package beyond.samdasoo.act.repository;
 import beyond.samdasoo.act.entity.Act;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ActRepository extends JpaRepository<Act, Long> {
+public interface ActRepository extends JpaRepository<Act, Long>, ActRepositoryCustom {
 }

--- a/src/main/java/beyond/samdasoo/act/repository/ActRepositoryCustom.java
+++ b/src/main/java/beyond/samdasoo/act/repository/ActRepositoryCustom.java
@@ -1,0 +1,9 @@
+package beyond.samdasoo.act.repository;
+
+import beyond.samdasoo.act.dto.ActStatusDto;
+
+import java.time.LocalDate;
+
+public interface ActRepositoryCustom {
+    ActStatusDto findActStatus(LocalDate searchDate, Long userNo);
+}

--- a/src/main/java/beyond/samdasoo/act/repository/ActRepositoryImpl.java
+++ b/src/main/java/beyond/samdasoo/act/repository/ActRepositoryImpl.java
@@ -1,0 +1,62 @@
+package beyond.samdasoo.act.repository;
+
+import beyond.samdasoo.act.dto.ActStatusDto;
+import beyond.samdasoo.act.entity.QAct;
+import beyond.samdasoo.customer.entity.QCustomer;
+import beyond.samdasoo.lead.Entity.QLead;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Repository
+@RequiredArgsConstructor
+public class ActRepositoryImpl implements ActRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public ActStatusDto findActStatus(LocalDate searchDate, Long userNo) {
+        QAct act = QAct.act;
+        QLead lead = QLead.lead;
+        QCustomer customer = QCustomer.customer;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (searchDate != null) {
+            builder.and(act.actDate.loe(searchDate));
+        }
+
+        if (userNo != null && userNo > 0) {
+            builder.and(customer.user.id.eq(userNo));
+        }
+
+        Long planCount = queryFactory
+                .select(act.count())
+                .from(act)
+                .join(act.lead, lead)
+                .join(lead.customer, customer)
+                .where(builder)
+                .fetchOne();
+
+        long planCnt = Objects.requireNonNullElse(planCount, 0L);
+
+        Long completeCount = queryFactory
+                .select(act.count())
+                .from(act)
+                .join(act.lead, lead)
+                .join(lead.customer, customer)
+                .where(builder
+                        .and(act.completeYn.eq("Y"))
+                )
+                .fetchOne();
+
+        long completeCnt = Objects.requireNonNullElse(completeCount, 0L);
+
+        long completePercent = planCnt > 0 ? (completeCnt * 100) / planCnt : 0;
+
+        return new ActStatusDto(planCnt, completeCnt, completePercent);
+    }
+}

--- a/src/main/java/beyond/samdasoo/act/service/ActService.java
+++ b/src/main/java/beyond/samdasoo/act/service/ActService.java
@@ -2,10 +2,12 @@ package beyond.samdasoo.act.service;
 
 import beyond.samdasoo.act.dto.ActRequestDto;
 import beyond.samdasoo.act.dto.ActResponseDto;
+import beyond.samdasoo.act.dto.ActStatusDto;
 import beyond.samdasoo.act.entity.Act;
 import beyond.samdasoo.act.entity.QAct;
 import beyond.samdasoo.act.repository.ActRepository;
 import beyond.samdasoo.calendar.repository.CalendarRepository;
+import beyond.samdasoo.common.dto.SearchCond;
 import beyond.samdasoo.common.exception.BaseException;
 import beyond.samdasoo.lead.Entity.Lead;
 import beyond.samdasoo.lead.repository.LeadRepository;
@@ -15,6 +17,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -155,5 +158,8 @@ public class ActService {
                 ));
     }
 
-
+    @Transactional(readOnly = true)
+    public ActStatusDto getActStatus(SearchCond searchCond) {
+        return actRepository.findActStatus(searchCond.getSearchDate(), searchCond.getUserNo());
+    }
 }

--- a/src/main/java/beyond/samdasoo/customer/controller/CustomerController.java
+++ b/src/main/java/beyond/samdasoo/customer/controller/CustomerController.java
@@ -1,5 +1,6 @@
 package beyond.samdasoo.customer.controller;
 
+import beyond.samdasoo.common.dto.SearchCond;
 import beyond.samdasoo.common.response.BaseResponse;
 import beyond.samdasoo.customer.dto.*;
 import beyond.samdasoo.customer.service.CustomerService;
@@ -10,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name="Customer APIs", description = "고객 API")
+@Tag(name = "Customer APIs", description = "고객 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/customers")
 @RestController
@@ -23,22 +24,22 @@ public class CustomerController {
      */
     @Operation(summary = "고객 등록", description = "새로운 고객 등록")
     @PostMapping("/add")
-    public BaseResponse<String> createCustomer(@RequestBody CustomerCreateReq req){
+    public BaseResponse<String> createCustomer(@RequestBody CustomerCreateReq req) {
         customerService.create(req);
 
         return new BaseResponse<>("고객 등록을 완료했습니다");
 
     }
+
     /*
      고객 조회 API
      */
     @GetMapping("/{id}")
-    public BaseResponse<CustomerGetRes> getCustomer(@PathVariable("id") Long id){
-        CustomerGetRes result= customerService.getCustomer(id);
+    public BaseResponse<CustomerGetRes> getCustomer(@PathVariable("id") Long id) {
+        CustomerGetRes result = customerService.getCustomer(id);
         return new BaseResponse<>(result);
 
     }
-
 
 
     /*
@@ -50,12 +51,12 @@ public class CustomerController {
         return new BaseResponse<>("고객 정보가 수정되었습니다");
     }
 
-
     /*
     고객 삭제 API
      */
     @DeleteMapping
-    public void deleteCustomer(){}
+    public void deleteCustomer() {
+    }
 
     /*
     고객 목록 조회 API
@@ -73,6 +74,13 @@ public class CustomerController {
     public BaseResponse<List<CustomersGetRes>> getCustomersByFilter(@RequestBody SearchCriteriaDTO searchCriteria){
 
         List<CustomersGetRes> result = customerService.getListByFilter(searchCriteria);
+        return new BaseResponse<>(result);
+    }
+
+    @PostMapping("/status/main")
+    @Operation(summary = "고객 필터 조회", description = "검색조건(생성일, 담당자)에 맞는 고객을 조회한다.")
+    public BaseResponse<Long> getCustomerCount(@RequestBody SearchCond searchCond) {
+        Long result = customerService.getCustomerCount(searchCond);
         return new BaseResponse<>(result);
     }
 }

--- a/src/main/java/beyond/samdasoo/customer/repository/CustomerRepositoryCustom.java
+++ b/src/main/java/beyond/samdasoo/customer/repository/CustomerRepositoryCustom.java
@@ -1,0 +1,7 @@
+package beyond.samdasoo.customer.repository;
+
+import java.time.LocalDate;
+
+public interface CustomerRepositoryCustom {
+    long getCustomerCount(LocalDate searchDate, Long userNo);
+}

--- a/src/main/java/beyond/samdasoo/customer/repository/CustomerRepositoryImpl.java
+++ b/src/main/java/beyond/samdasoo/customer/repository/CustomerRepositoryImpl.java
@@ -1,0 +1,40 @@
+package beyond.samdasoo.customer.repository;
+
+import beyond.samdasoo.customer.entity.QCustomer;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Objects;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomerRepositoryImpl implements CustomerRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long getCustomerCount(LocalDate searchDate, Long userNo) {
+        QCustomer customer = QCustomer.customer;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (searchDate != null) {
+            builder.and(customer.createdAt.loe(searchDate.atTime(LocalTime.MAX)));
+        }
+
+        if (userNo != null && userNo > 0) {
+            builder.and(customer.user.id.eq(userNo));
+        }
+
+        Long result = queryFactory
+                .select(customer.count())
+                .from(customer)
+                .where(builder)
+                .fetchOne();
+
+        return Objects.requireNonNullElse(result, 0L);
+    }
+}

--- a/src/main/java/beyond/samdasoo/customer/service/CustomerService.java
+++ b/src/main/java/beyond/samdasoo/customer/service/CustomerService.java
@@ -1,10 +1,12 @@
 package beyond.samdasoo.customer.service;
 
+import beyond.samdasoo.common.dto.SearchCond;
 import beyond.samdasoo.common.exception.BaseException;
 import beyond.samdasoo.common.utils.UserUtil;
 import beyond.samdasoo.customer.dto.*;
 import beyond.samdasoo.customer.entity.Customer;
 import beyond.samdasoo.customer.repository.CustomerRepository;
+import beyond.samdasoo.customer.repository.CustomerRepositoryCustom;
 import beyond.samdasoo.user.entity.User;
 import beyond.samdasoo.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -23,6 +25,7 @@ public class CustomerService {
 
     private final CustomerRepository customerRepository;
     private final UserRepository userRepository;
+    private final CustomerRepositoryCustom customerRepositoryCustom;
 
     public void create(CustomerCreateReq req) {
 
@@ -100,6 +103,10 @@ public class CustomerService {
         Optional.ofNullable(request.getGrade()).ifPresent(customer::changeGrade);
         Optional.of(request.isKeyMan()).ifPresent(customer::changeKeyman);
 
+    }
+
+    public Long getCustomerCount(SearchCond searchCond) {
+        return customerRepositoryCustom.getCustomerCount(searchCond.getSearchDate(), searchCond.getUserNo());
     }
 }
 

--- a/src/main/java/beyond/samdasoo/lead/controller/LeadController.java
+++ b/src/main/java/beyond/samdasoo/lead/controller/LeadController.java
@@ -1,15 +1,17 @@
 package beyond.samdasoo.lead.controller;
 
+import beyond.samdasoo.common.dto.SearchCond;
 import beyond.samdasoo.common.response.BaseResponse;
 import beyond.samdasoo.lead.dto.LeadRequestDto;
 import beyond.samdasoo.lead.dto.LeadResponseDto;
 import beyond.samdasoo.lead.dto.LeadSearchCond;
+import beyond.samdasoo.lead.dto.LeadStatusDto;
 import beyond.samdasoo.lead.service.LeadService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,6 +21,7 @@ import java.util.List;
 @RequestMapping("/api/leads")
 @Tag(name = "Lead APIs", description = "영업기회 API")
 public class LeadController {
+    private static final Logger log = LoggerFactory.getLogger(LeadController.class);
     private final LeadService leadService;
 
     @PostMapping
@@ -61,5 +64,12 @@ public class LeadController {
     public BaseResponse<String> deleteLead(@PathVariable Long no) {
         leadService.deleteLead(no);
         return new BaseResponse<>(no + " 영업기회가 삭제됐습니다.");
+    }
+
+    @PostMapping("/status/main")
+    @Operation(summary = "영업기회 상태별 조회", description = "영업기회 Status group by 조회(검색조건: 시작일자, 고객.담당자번호)")
+    public BaseResponse<List<LeadStatusDto>> getLeadStatusMain(@RequestBody SearchCond searchCond) {
+        List<LeadStatusDto> leadStatus = leadService.getLeadStatusGroupedByStatus(searchCond);
+        return new BaseResponse<>(leadStatus);
     }
 }

--- a/src/main/java/beyond/samdasoo/lead/dto/LeadStatusDto.java
+++ b/src/main/java/beyond/samdasoo/lead/dto/LeadStatusDto.java
@@ -1,0 +1,12 @@
+package beyond.samdasoo.lead.dto;
+
+import beyond.samdasoo.lead.Entity.LeadStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LeadStatusDto {
+    private LeadStatus status;
+    private long count;
+}

--- a/src/main/java/beyond/samdasoo/lead/repository/LeadRepositoryCustom.java
+++ b/src/main/java/beyond/samdasoo/lead/repository/LeadRepositoryCustom.java
@@ -1,0 +1,10 @@
+package beyond.samdasoo.lead.repository;
+
+import beyond.samdasoo.lead.dto.LeadStatusDto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface LeadRepositoryCustom {
+    List<LeadStatusDto> findLeadStatusGroupedByStatus(LocalDate searchDate, Long userNo);
+}

--- a/src/main/java/beyond/samdasoo/lead/repository/LeadRepositoryImpl.java
+++ b/src/main/java/beyond/samdasoo/lead/repository/LeadRepositoryImpl.java
@@ -1,0 +1,46 @@
+package beyond.samdasoo.lead.repository;
+
+import beyond.samdasoo.customer.entity.QCustomer;
+import beyond.samdasoo.lead.Entity.QLead;
+import beyond.samdasoo.lead.dto.LeadStatusDto;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class LeadRepositoryImpl implements LeadRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<LeadStatusDto> findLeadStatusGroupedByStatus(LocalDate searchDate, Long userNo) {
+        QLead lead = QLead.lead;
+        QCustomer customer = QCustomer.customer;
+
+        BooleanBuilder whereClause = new BooleanBuilder();
+
+        if (searchDate != null) {
+            whereClause.and(lead.startDate.loe(searchDate));
+        }
+
+        if (userNo != null && userNo > 0) {
+            whereClause.and(customer.user.id.eq(userNo));
+        }
+
+        return queryFactory
+                .select(Projections.constructor(LeadStatusDto.class,
+                        lead.status,
+                        lead.count().as("count")
+                ))
+                .from(lead)
+                .join(lead.customer, customer)
+                .where(whereClause)
+                .groupBy(lead.status)
+                .fetch();
+    }
+}

--- a/src/main/java/beyond/samdasoo/lead/service/LeadService.java
+++ b/src/main/java/beyond/samdasoo/lead/service/LeadService.java
@@ -4,6 +4,7 @@ import beyond.samdasoo.admin.entity.Process;
 import beyond.samdasoo.admin.entity.SubProcess;
 import beyond.samdasoo.admin.repository.ProcessRepository;
 import beyond.samdasoo.admin.repository.SubProcessRepository;
+import beyond.samdasoo.common.dto.SearchCond;
 import beyond.samdasoo.common.exception.BaseException;
 import beyond.samdasoo.customer.entity.Customer;
 import beyond.samdasoo.customer.repository.CustomerRepository;
@@ -13,7 +14,9 @@ import beyond.samdasoo.lead.Entity.Step;
 import beyond.samdasoo.lead.dto.LeadRequestDto;
 import beyond.samdasoo.lead.dto.LeadResponseDto;
 import beyond.samdasoo.lead.dto.LeadSearchCond;
+import beyond.samdasoo.lead.dto.LeadStatusDto;
 import beyond.samdasoo.lead.repository.LeadRepository;
+import beyond.samdasoo.lead.repository.LeadRepositoryCustom;
 import beyond.samdasoo.lead.repository.StepRepository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -35,6 +38,7 @@ import static beyond.samdasoo.common.response.BaseResponseStatus.*;
 public class LeadService {
     private final JPAQueryFactory queryFactory;
     private final LeadRepository leadRepository;
+    private final LeadRepositoryCustom leadRepositoryCustom;
     private final CustomerRepository customerRepository;
     private final ProcessRepository processRepository;
     private final SubProcessRepository subProcessRepository;
@@ -183,5 +187,11 @@ public class LeadService {
 
             stepRepository.save(step);
         }
+    }
+
+    public List<LeadStatusDto> getLeadStatusGroupedByStatus(SearchCond searchCond) {
+        return leadRepositoryCustom.findLeadStatusGroupedByStatus(
+                searchCond.getSearchDate(), searchCond.getUserNo()
+        );
     }
 }

--- a/src/main/java/beyond/samdasoo/potentialcustomer/controller/PotentialCustomerController.java
+++ b/src/main/java/beyond/samdasoo/potentialcustomer/controller/PotentialCustomerController.java
@@ -1,34 +1,30 @@
 package beyond.samdasoo.potentialcustomer.controller;
 
+import beyond.samdasoo.common.dto.SearchCond;
 import beyond.samdasoo.common.exception.BaseException;
 import beyond.samdasoo.common.response.BaseResponse;
 import beyond.samdasoo.potentialcustomer.dto.*;
-import beyond.samdasoo.potentialcustomer.entity.ContactHistory;
-import beyond.samdasoo.potentialcustomer.entity.PotentialCustomer;
 import beyond.samdasoo.potentialcustomer.service.PotentialCustomerService;
-import beyond.samdasoo.user.dto.JoinUserReq;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.task.ThreadPoolTaskExecutorBuilder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 import static beyond.samdasoo.common.response.BaseResponseStatus.*;
-import static beyond.samdasoo.common.response.BaseResponseStatus.NAME_EMPTY;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/pcustomers")
-@Tag(name="PotentialCustomer APIs", description = "잠재고객 API")
+@Tag(name = "PotentialCustomer APIs", description = "잠재고객 API")
 @RestController
 public class PotentialCustomerController {
 
     private final PotentialCustomerService potentialCustomerService;
 
     /**
-     잠재고객 생성 API
+     * 잠재고객 생성 API
      */
     @PostMapping("")
     @Operation(summary = "잠재고객 등록", description = "새로운 잠재고객을 등록한다")
@@ -41,11 +37,11 @@ public class PotentialCustomerController {
 
 
     /**
-     잠재고객 정보 수정 API
+     * 잠재고객 정보 수정 API
      */
     @PatchMapping("/{prospectId}")
     @Operation(summary = "잠재고객 수정", description = "잠재고객 정보를 수정한다")
-    public BaseResponse<String> updatePotentialCustomer(@PathVariable Long prospectId,@RequestBody UpdatePotentialCustomerReq request) {
+    public BaseResponse<String> updatePotentialCustomer(@PathVariable Long prospectId, @RequestBody UpdatePotentialCustomerReq request) {
         potentialCustomerService.updatePotentialCustomer(prospectId, request);
         return new BaseResponse<>("고객 정보가 수정되었습니다");
     }
@@ -63,7 +59,7 @@ public class PotentialCustomerController {
 
 
     /**
-     *  잠재고객 목록 조회 API
+     * 잠재고객 목록 조회 API
      */
     @GetMapping
     @Operation(summary = "잠재고객 목록 조회", description = "잠재고객 목록을 조회한다")
@@ -73,21 +69,21 @@ public class PotentialCustomerController {
     }
 
     /**
-        접촉 이력 생성 API
+     * 접촉 이력 생성 API
      */
     @PostMapping("/{prospectId}/history")
     @Operation(summary = "접촉이력 등록", description = "잠재고객에 대한 접촉이력을 등록한다")
-    public BaseResponse<String> insertContactHistory(@PathVariable Long prospectId,@RequestBody @Valid CreateContactHistoryReq request){
-        potentialCustomerService.insertContactHistory(prospectId,request);
+    public BaseResponse<String> insertContactHistory(@PathVariable Long prospectId, @RequestBody @Valid CreateContactHistoryReq request) {
+        potentialCustomerService.insertContactHistory(prospectId, request);
         return new BaseResponse<>("새 이력을 등록했습니다");
     }
 
     /**
-        접촉 이력 목록 조회 API -> 목록 조회시 pk 값도 응답값에 추가
+     * 접촉 이력 목록 조회 API -> 목록 조회시 pk 값도 응답값에 추가
      */
     @GetMapping("{prospectId}/history")
     @Operation(summary = "접촉이력 목록 조회", description = "특정 잠재고객에 대한 접촉이력 목록을 조회한다")
-    public BaseResponse<List<ContactHistoryDto>> getContactHistoryList(@PathVariable Long prospectId){
+    public BaseResponse<List<ContactHistoryDto>> getContactHistoryList(@PathVariable Long prospectId) {
         List<ContactHistoryDto> result = potentialCustomerService.getContactHistoryList(prospectId);
 
         return new BaseResponse<>(result);
@@ -95,7 +91,7 @@ public class PotentialCustomerController {
     }
 
     /**
-        접촉 이력 삭제 API
+     * 접촉 이력 삭제 API
      */
     @DeleteMapping("/history/{historyId}")
     @Operation(summary = "접촉이력 삭제", description = "특정 접촉 이력을 삭제한다")
@@ -107,19 +103,25 @@ public class PotentialCustomerController {
     }
 
     private void validateInputEmptyCreate(CreatePotentialCustomerReq req) {
-        if (req.getName().trim().isEmpty()||req.getName()==null) { // 이름
+        if (req.getName().trim().isEmpty() || req.getName() == null) { // 이름
             throw new BaseException(NAME_EMPTY);
         }
-        if (req.getCls().isEmpty()|| req.getCls()==null) { // 접촉구분
+        if (req.getCls().isEmpty() || req.getCls() == null) { // 접촉구분
             throw new BaseException(PC_CLS_EMPTY);
         }
-        if(req.getContactStatus().isEmpty()||req.getContactStatus()==null){ // 접촉상태
+        if (req.getContactStatus().isEmpty() || req.getContactStatus() == null) { // 접촉상태
             throw new BaseException(PC_STATUS_EMPTY);
         }
-        if(req.getPhone().isEmpty()||req.getPhone()==null){ // 핸드폰
+        if (req.getPhone().isEmpty() || req.getPhone() == null) { // 핸드폰
             throw new BaseException(PC_PHONE_EMPTY);
         }
 
     }
 
+    @PostMapping("/status/main")
+    @Operation(summary = "잠재고객 필터 조회", description = "검색조건(생성일, 담당자)에 맞는 잠재고객을 조회한다.")
+    public BaseResponse<Long> getCustomerCount(@RequestBody SearchCond searchCond) {
+        Long result = potentialCustomerService.getPotentialCustomerCount(searchCond);
+        return new BaseResponse<>(result);
+    }
 }

--- a/src/main/java/beyond/samdasoo/potentialcustomer/repository/PotentialCustomerRepositoryCustom.java
+++ b/src/main/java/beyond/samdasoo/potentialcustomer/repository/PotentialCustomerRepositoryCustom.java
@@ -1,0 +1,7 @@
+package beyond.samdasoo.potentialcustomer.repository;
+
+import java.time.LocalDate;
+
+public interface PotentialCustomerRepositoryCustom {
+    long getPotentialCustomerCount(LocalDate searchDate, Long userNo);
+}

--- a/src/main/java/beyond/samdasoo/potentialcustomer/repository/PotentialCustomerRepositoryImpl.java
+++ b/src/main/java/beyond/samdasoo/potentialcustomer/repository/PotentialCustomerRepositoryImpl.java
@@ -1,0 +1,40 @@
+package beyond.samdasoo.potentialcustomer.repository;
+
+import beyond.samdasoo.potentialcustomer.entity.QPotentialCustomer;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Objects;
+
+@Repository
+@RequiredArgsConstructor
+public class PotentialCustomerRepositoryImpl implements PotentialCustomerRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long getPotentialCustomerCount(LocalDate searchDate, Long userNo) {
+        QPotentialCustomer potentialCustomer = QPotentialCustomer.potentialCustomer;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (searchDate != null) {
+            builder.and(potentialCustomer.createdAt.loe(searchDate.atTime(LocalTime.MAX)));
+        }
+
+//        if (userNo != null && userNo != 0) {
+//            builder.and(potentialCustomer.user.id.eq(userNo));
+//        }
+
+        Long result = queryFactory
+                .select(potentialCustomer.count())
+                .from(potentialCustomer)
+                .where(builder)
+                .fetchOne();
+
+        return Objects.requireNonNullElse(result, 0L);
+    }
+}

--- a/src/main/java/beyond/samdasoo/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/beyond/samdasoo/user/repository/UserRepositoryImpl.java
@@ -6,10 +6,12 @@ import beyond.samdasoo.user.entity.QUser;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Repository
 @RequiredArgsConstructor
 public class UserRepositoryImpl implements UserRepositoryCustom {
 


### PR DESCRIPTION
## 📢 작업 내용 설명
> 메인페이지 고객, 잠재고객, 영업기회, 영업활동 통계 api 추가
- 각 엔티티 별 queryDsl 관련 인터페이스, 클래스, ResponseDto 추가

<br>

![image](https://github.com/user-attachments/assets/2582d584-a1d2-43fc-8eb1-7740ff63770d)

<br>

## #️⃣연관된  issue
#106 

<br>

## ✅ 체크리스트
- [x] 새로운 기능 추가

<br>

## 📑To Reviewers (선택)

- 목표 및 실적은 오후에
