### PR TITLE
[Feat/#111] 사용자 인증 기반 캘린더 관리 구현

### DIFF
--- a/src/main/java/beyond/samdasoo/act/entity/Act.java
+++ b/src/main/java/beyond/samdasoo/act/entity/Act.java
@@ -1,6 +1,7 @@
 package beyond.samdasoo.act.entity;
 
 import beyond.samdasoo.calendar.entity.Calendar;
+import beyond.samdasoo.common.entity.BaseEntity;
 import beyond.samdasoo.lead.Entity.Lead;
 import beyond.samdasoo.plan.entity.Plan;
 import jakarta.persistence.*;
@@ -17,7 +18,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name="tb_act")
-public class Act {
+public class Act extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/beyond/samdasoo/calendar/controller/CalendarController.java
+++ b/src/main/java/beyond/samdasoo/calendar/controller/CalendarController.java
@@ -1,43 +1,63 @@
 package beyond.samdasoo.calendar.controller;
 
-import beyond.samdasoo.calendar.dto.CalendarRequestDto;
 import beyond.samdasoo.calendar.dto.CalendarResponseDto;
 import beyond.samdasoo.calendar.service.CalendarService;
 import beyond.samdasoo.common.exception.BaseException;
 import beyond.samdasoo.common.response.BaseResponse;
 import beyond.samdasoo.common.response.BaseResponseStatus;
+import beyond.samdasoo.user.entity.User;
+import beyond.samdasoo.user.repository.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 import static beyond.samdasoo.common.response.BaseResponseStatus.CALENDAR_ALREADY_EXIST;
+import static beyond.samdasoo.common.response.BaseResponseStatus.USER_NOT_EXIST;
 
 @RestController
 @RequestMapping("/api/calendars")
-@Tag(name="Calendars APIs", description = "캘린더 API")
+@Tag(name = "Calendars APIs", description = "캘린더 API")
 public class CalendarController {
     private final CalendarService calendarService;
+    private final UserRepository userRepository;
 
-    public CalendarController(CalendarService calendarService) {
+    public CalendarController(CalendarService calendarService, UserRepository userRepository) {
         this.calendarService = calendarService;
+        this.userRepository = userRepository;
+    }
+
+    private User getAuthenticatedUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email;
+        // 일단 이메일만
+        if (authentication.getPrincipal() instanceof String) {
+            email = (String) authentication.getPrincipal();
+        } else {
+            throw new BaseException(USER_NOT_EXIST);
+        }
+
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new BaseException(USER_NOT_EXIST));
     }
 
     @PostMapping
     @Operation(summary = "캘린더 등록", description = "새로운 캘린더 등록")
-    public ResponseEntity<BaseResponse<CalendarResponseDto>> createCalendar(@RequestBody CalendarRequestDto requestDto) {
-        boolean calendarExists = calendarService.existsByUserId(requestDto.getUserNo());
+    public ResponseEntity<BaseResponse<CalendarResponseDto>> createCalendar() {
+        User user = getAuthenticatedUser();
+        boolean calendarExists = calendarService.existsByUser(user);
 
         if (calendarExists) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(new BaseResponse<>(CALENDAR_ALREADY_EXIST));
         }
-        CalendarResponseDto responseDto = calendarService.createCalendar(requestDto);
+        CalendarResponseDto responseDto = calendarService.createCalendar(user);
         return ResponseEntity.status(HttpStatus.CREATED).body(new BaseResponse<>(responseDto));
     }
-
 
     @GetMapping("/{no}")
     @Operation(summary = "캘린더 조회", description = "특정 캘린더 조회")
@@ -51,34 +71,36 @@ public class CalendarController {
         }
     }
 
-    @GetMapping
-    @Operation(summary = "전체 캘린더 조회", description = "모든 캘린더 조회")
-    public ResponseEntity<BaseResponse<List<CalendarResponseDto>>> getAllCalendars() {
-        try{
-            List<CalendarResponseDto> calendars = calendarService.getAllCalendars();
-            return ResponseEntity.ok(new BaseResponse<>(calendars));
-        }catch (BaseException ex) {
+    @GetMapping("/user/exists")
+    @Operation(summary = "캘린더 존재 여부 확인", description = "로그인한 사용자의 캘린더 보유 여부 조회")
+    public ResponseEntity<BaseResponse<Boolean>> checkCalendarExists() {
+        User user = getAuthenticatedUser();
+        boolean exists = calendarService.existsByUser(user);
+        return ResponseEntity.ok(new BaseResponse<>(exists));
+    }
+
+    @GetMapping("/user/data")
+    @Operation(summary = "사용자의 캘린더 조회", description = "로그인한 사용자의 캘린더를 조회")
+    public ResponseEntity<BaseResponse<CalendarResponseDto>> getUserCalendarData() {
+        User user = getAuthenticatedUser();
+        try {
+            CalendarResponseDto responseDto = calendarService.getCalendarDataByUser(user);
+            return ResponseEntity.ok(new BaseResponse<>(responseDto));
+        } catch (BaseException ex) {
             BaseResponseStatus status = ex.getStatus();
             return new ResponseEntity<>(new BaseResponse<>(status), HttpStatus.valueOf(status.getCode()));
         }
     }
-//    @PatchMapping("/{no}")
-//    @Operation(summary = "캘린더 수정", description = "특정 캘린더를 수정합니다.")
-//    public ResponseEntity<BaseResponse<String>> updateCalendar(@PathVariable Long no, @RequestBody CalendarRequestDto calendarRequestDto) {
-//        try {
-//            calendarService.updateCalendar(no, calendarRequestDto);
-//            return ResponseEntity.ok(new BaseResponse<>("캘린더를 수정하였습니다"));
-//        } catch (BaseException ex) {
-//            BaseResponseStatus status = ex.getStatus();
-//            return new ResponseEntity<>(new BaseResponse<>(status), HttpStatus.valueOf(status.getCode()));
-//        }
-//    }
 
-    @GetMapping("/user/{userId}/exists")
-    @Operation(summary = "캘린더 존재 여부 확인", description = "캘린더 보유 여부 조회")
-    public ResponseEntity<BaseResponse<Boolean>> checkCalendarExists(@PathVariable Long userId) {
-        boolean exists = calendarService.existsByUserId(userId);
-        return ResponseEntity.ok(new BaseResponse<>(exists));
+    @GetMapping
+    @Operation(summary = "전체 캘린더 조회", description = "모든 캘린더 조회")
+    public ResponseEntity<BaseResponse<List<CalendarResponseDto>>> getAllCalendars() {
+        try {
+            List<CalendarResponseDto> calendars = calendarService.getAllCalendars();
+            return ResponseEntity.ok(new BaseResponse<>(calendars));
+        } catch (BaseException ex) {
+            BaseResponseStatus status = ex.getStatus();
+            return new ResponseEntity<>(new BaseResponse<>(status), HttpStatus.valueOf(status.getCode()));
+        }
     }
-
 }

--- a/src/main/java/beyond/samdasoo/calendar/dto/CalendarResponseDto.java
+++ b/src/main/java/beyond/samdasoo/calendar/dto/CalendarResponseDto.java
@@ -1,9 +1,12 @@
 package beyond.samdasoo.calendar.dto;
 
 import beyond.samdasoo.act.dto.ActResponseDto;
+import beyond.samdasoo.act.entity.Act;
 import beyond.samdasoo.calendar.entity.Calendar;
 import beyond.samdasoo.plan.dto.PlanResponseDto;
+import beyond.samdasoo.plan.entity.Plan;
 import beyond.samdasoo.todo.dto.TodoResponseDto;
+import beyond.samdasoo.todo.entity.Todo;
 import lombok.Data;
 
 import java.util.ArrayList;
@@ -32,6 +35,14 @@ public class CalendarResponseDto {
         this.acts = (calendar.getActs() != null) ?
                 calendar.getActs().stream().map(ActResponseDto::new).collect(Collectors.toList()) :
                 new ArrayList<>();
+    }
+
+    public CalendarResponseDto(Calendar calendar, List<Todo> todos, List<Plan> plans, List<Act> acts) {
+        this.calendarNo = calendar.getNo();
+        this.userName = calendar.getUser().getName();
+        this.todos = todos.stream().map(TodoResponseDto::new).collect(Collectors.toList());
+        this.plans = plans.stream().map(PlanResponseDto::new).collect(Collectors.toList());
+        this.acts = acts.stream().map(ActResponseDto::new).collect(Collectors.toList());
     }
 }
 

--- a/src/main/java/beyond/samdasoo/calendar/entity/Calendar.java
+++ b/src/main/java/beyond/samdasoo/calendar/entity/Calendar.java
@@ -1,6 +1,7 @@
 package beyond.samdasoo.calendar.entity;
 
 import beyond.samdasoo.act.entity.Act;
+import beyond.samdasoo.common.entity.BaseEntity;
 import beyond.samdasoo.plan.entity.Plan;
 import beyond.samdasoo.todo.entity.Todo;
 import beyond.samdasoo.user.entity.User;
@@ -19,7 +20,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name="tb_calendar")
-public class Calendar {
+public class Calendar extends BaseEntity {
 
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/beyond/samdasoo/calendar/repository/CalendarRepository.java
+++ b/src/main/java/beyond/samdasoo/calendar/repository/CalendarRepository.java
@@ -2,7 +2,10 @@ package beyond.samdasoo.calendar.repository;
 
 import beyond.samdasoo.calendar.entity.Calendar;
 import beyond.samdasoo.common.exception.BaseException;
+import beyond.samdasoo.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 import static beyond.samdasoo.common.response.BaseResponseStatus.CALENDAR_NOT_EXIST;
 
@@ -10,5 +13,6 @@ public interface CalendarRepository extends JpaRepository<Calendar, Long> {
     default Calendar findCalendarById(Long id) {
         return findById(id).orElseThrow(() -> new BaseException(CALENDAR_NOT_EXIST));
     }
-    boolean existsByUser_Id(Long id);
+    Optional<Calendar> findByUser(User user);
+    boolean existsByUser(User user);
 }

--- a/src/main/java/beyond/samdasoo/calendar/service/CalendarService.java
+++ b/src/main/java/beyond/samdasoo/calendar/service/CalendarService.java
@@ -1,10 +1,12 @@
 package beyond.samdasoo.calendar.service;
 
-import beyond.samdasoo.calendar.dto.CalendarRequestDto;
+import beyond.samdasoo.act.entity.Act;
 import beyond.samdasoo.calendar.dto.CalendarResponseDto;
 import beyond.samdasoo.calendar.entity.Calendar;
 import beyond.samdasoo.calendar.repository.CalendarRepository;
 import beyond.samdasoo.common.exception.BaseException;
+import beyond.samdasoo.plan.entity.Plan;
+import beyond.samdasoo.todo.entity.Todo;
 import beyond.samdasoo.user.entity.User;
 import beyond.samdasoo.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -13,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static beyond.samdasoo.common.response.BaseResponseStatus.USER_NOT_EXIST;
+import static beyond.samdasoo.common.response.BaseResponseStatus.CALENDAR_NOT_EXIST;
 
 @Service
 public class CalendarService {
@@ -25,11 +27,7 @@ public class CalendarService {
         this.userRepository = userRepository;
     }
 
-    public CalendarResponseDto createCalendar(CalendarRequestDto requestDto) {
-
-        User user = userRepository.findById(requestDto.getUserNo())
-                .orElseThrow(() -> new BaseException(USER_NOT_EXIST));
-
+    public CalendarResponseDto createCalendar(User user) {
         Calendar calendar = Calendar.builder()
                 .user(user)
                 .plans(new ArrayList<>())
@@ -46,25 +44,26 @@ public class CalendarService {
         return new CalendarResponseDto(calendar);
     }
 
+    // 사용자 관련 모든 데이터
+    public CalendarResponseDto getCalendarDataByUser(User user) {
+        Calendar calendar = cRepo.findByUser(user)
+                .orElseThrow(() -> new BaseException(CALENDAR_NOT_EXIST));
+
+        List<Todo> todos = calendar.getTodos();
+        List<Plan> plans = calendar.getPlans();
+        List<Act> acts = calendar.getActs();
+
+        return new CalendarResponseDto(calendar, todos, plans, acts);
+    }
+
     public List<CalendarResponseDto> getAllCalendars() {
         return cRepo.findAll().stream()
                 .map(CalendarResponseDto::new)
                 .collect(Collectors.toList());
     }
 
-//    @Transactional
-//    public void updateCalendar(Long no, CalendarRequestDto calendarRequestDto) {
-//        Calendar calendar = cRepo.findCalendarById(no);
-//        User user = userRepository.findById(calendarRequestDto.getUserNo())
-//                .orElseThrow(() -> new BaseException(USER_NOT_EXIST));
-//
-//        calendar.setUser(user);
-//
-//        cRepo.save(calendar);
-//    }
-
-    public boolean existsByUserId(Long userId) {
-        return cRepo.existsByUser_Id(userId);
+    public boolean existsByUser(User user) {
+        return cRepo.existsByUser(user);
     }
 
 }

--- a/src/main/java/beyond/samdasoo/user/service/UserService.java
+++ b/src/main/java/beyond/samdasoo/user/service/UserService.java
@@ -2,6 +2,9 @@ package beyond.samdasoo.user.service;
 
 import beyond.samdasoo.admin.entity.Department;
 import beyond.samdasoo.admin.repository.DepartmentRepository;
+import beyond.samdasoo.calendar.entity.Calendar;
+import beyond.samdasoo.calendar.repository.CalendarRepository;
+import beyond.samdasoo.calendar.service.CalendarService;
 import beyond.samdasoo.common.email.CertificationNumber;
 import beyond.samdasoo.common.email.EmailProvider;
 import beyond.samdasoo.common.email.EmailRepository;
@@ -22,6 +25,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -40,6 +44,7 @@ public class UserService {
     private final EmailProvider emailProvider;
     private final EmailRepository emailRepository;
     private final EmailVerificationUserRedisRepository emailVerificationUserRedisRepository;
+    private final CalendarService calendarService;
 
 
     public JoinUserRes join(JoinUserReq joinUserReq) {
@@ -60,6 +65,9 @@ public class UserService {
         User newUser = joinUserReq.toUser(encoder.encode(joinUserReq.getPassword()), generateEmployeeId(), department);
 
         User saveUser = userRepository.save(newUser);
+
+        // 사용자 가입 시 캘린더 생성
+        calendarService.createCalendar(saveUser);
 
         return new JoinUserRes(saveUser.getEmployeeId());
     }

--- a/src/main/resources/base.sql
+++ b/src/main/resources/base.sql
@@ -5,7 +5,7 @@ VALUES
     (4, 'user3@example.com', 'EMP004', '2024-04-10', '최미진', 'password123', 'USER', 4, NOW(), NOW()),
     (5, 'user4@example.com', 'EMP005', '2024-05-15', '정우진', 'password123', 'USER', 5, NOW(), NOW());
 
-INSERT INTO tb_calendar (user_no) VALUES (1), (2), (3), (4), (5);
+# INSERT INTO tb_calendar (user_no) VALUES (1), (2), (3), (4), (5);
 
 INSERT INTO tb_process (process_no, created_at, updated_at, description, expected_duration, is_default, process_name)
 VALUES
@@ -23,29 +23,31 @@ VALUES
     (NOW(), NOW(), 'EDUCATION', '2024-05-01', '2024-09-01', 600, 2200, 5500, '교육 프로그램 참여', '교육 프로그램 제공 논의', 4, 'HOLD', 4, 65, 4),
     (NOW(), NOW(), 'SEARCH', '2024-04-10', '2024-10-10', 900, 3200, 7500, '검색 통한 신규 고객 확보', '검색 마케팅 준비', 5, 'PROGRESS', 5, 85, 5);
 
-INSERT INTO tb_act (no, act_cont, act_date, cls, complete_yn, end_time, name, plan_cont, purpose, start_time, calendar_no, lead_no)
+INSERT INTO tb_act (created_at, updated_at, no, act_cont, act_date, cls, complete_yn, end_time, name, plan_cont, purpose, start_time, calendar_no, lead_no)
 VALUES
-    (1, '화상 회의 플랫폼 논의', '2024-07-01', 'ONLINE', 'N', '15:00', '프로젝트 회의 준비', '신규 회의 준비', '프로젝트 논의', '13:00', 2, 1),
-    (2, '거래처 방문', '2024-07-03', 'VISIT', 'Y', '17:00', '거래처 미팅', '계약 관련 회의', '상담 및 계약 체결', '15:00', 2, 2),
-    (3, '전화 문의 응대', '2024-07-05', 'PHONE', 'N', '11:30', '문의사항 해결', '고객 문의 사항 응대', '고객 응대', '10:00', 2, 3),
-    (4, '이메일 발송', '2024-07-07', 'EMAIL', 'Y', '14:00', '정보 이메일 발송', '상품 정보 제공', '상품 홍보 및 고객 안내', '13:00', 2, 4),
-    (5, '온라인 미팅 준비', '2024-07-09', 'OTHER', 'N', '16:00', '프로젝트 미팅', '프로젝트 논의', '프로젝트 진행 상황 점검', '14:00', 2, 5);
+    (NOW(), NOW(), 1, '화상 회의 플랫폼 논의', '2024-10-01', 'ONLINE', 'N', '15:00', '프로젝트 회의 준비', '신규 회의 준비', '프로젝트 논의', '13:00', 1, 1),
+    (NOW(), NOW(), 2, '거래처 방문', '2024-10-03', 'VISIT', 'Y', '17:00', '거래처 미팅', '계약 관련 회의', '상담 및 계약 체결', '15:00', 1, 2),
+    (NOW(), NOW(), 3, '전화 문의 응대', '2024-10-05', 'PHONE', 'N', '11:30', '문의사항 해결', '고객 문의 사항 응대', '고객 응대', '10:00', 1, 3),
+    (NOW(), NOW(), 4, '이메일 발송', '2024-10-07', 'EMAIL', 'Y', '14:00', '정보 이메일 발송', '상품 정보 제공', '상품 홍보 및 고객 안내', '13:00', 1, 4),
+    (NOW(), NOW(), 5, '온라인 미팅 준비', '2024-11-01', 'OTHER', 'N', '16:00', '프로젝트 미팅', '프로젝트 논의', '프로젝트 진행 상황 점검', '14:00', 1, 5);
 
 INSERT INTO tb_plan (no, created_at, updated_at, content, end_time, personal_yn, plan_cls, plan_date, start_time, title, calendar_no)
 VALUES
-    (1, NOW(), NOW(), '팀원 전체 회의', '10:00', 'N', 'COMPANY', '2024-07-02', '09:00', '회의 일정', 2),
-    (2, NOW(), NOW(), '신규 계약 검토', '15:00', 'Y', 'CONTRACT', '2024-07-04', '13:00', '계약 검토', 2),
-    (3, NOW(), NOW(), '개인 개발 공부', '22:00', 'Y', 'PERSONAL', '2024-07-06', '20:00', '개인 학습', 2),
-    (4, NOW(), NOW(), '견적서 작성', '17:00', 'N', 'ESTIMATE', '2024-07-08', '15:00', '견적서 작업', 2),
-    (5, NOW(), NOW(), '영업 전략 회의', '16:00', 'N', 'SALES', '2024-07-10', '14:00', '영업 전략 논의', 2);
+    (1, NOW(), NOW(), '팀원 전체 회의', '10:00', 'N', 'COMPANY', '2024-11-02', '09:00', '회의 일정', 1),
+    (2, NOW(), NOW(), '신규 계약 검토', '15:00', 'Y', 'CONTRACT', '2024-10-04', '13:00', '계약 검토', 1),
+    (3, NOW(), NOW(), '개인 개발 공부', '22:00', 'Y', 'PERSONAL', '2024-10-21', '20:00', '개인 학습', 1),
+    (4, NOW(), NOW(), '견적서 작성', '17:00', 'N', 'ESTIMATE', '2024-10-11', '15:00', '견적서 작업', 1),
+    (5, NOW(), NOW(), '영업 전략 회의', '16:00', 'N', 'SALES', '2024-10-3', '14:00', '영업 전략 논의', 1),
+    (6, NOW(), NOW(), '제안서 서식 정리', '22:00', 'Y', 'PROPOSAL', '2024-10-14', '10:00', '제안서 서식', 1),
+    (7, NOW(), NOW(), 'OJT', '17:00', 'N', 'COMPANY', '2024-10-17', '15:00', '신입사원 OJT', 1);
 
 INSERT INTO tb_todo (todo_no, created_at, updated_at, content, due_date, priority, private_yn, status, title, todo_cls, calendar_no)
 VALUES
-    (1, NOW(), NOW(), '고객사 자료 준비', '2024-07-02', 'HIGH', 'N', 'TODO', '자료 준비', 'SALES', 2),
-    (2, NOW(), NOW(), '팀 회의 참석', '2024-07-03', 'MEDIUM', 'N', 'INPROGRESS', '회의 참여', 'COMPANY', 2),
-    (3, NOW(), NOW(), '개인 일정 조율', '2024-07-04', 'LOW', 'Y', 'DONE', '일정 조율', 'PERSONAL', 2),
-    (4, NOW(), NOW(), '계약서 내용 확인', '2024-07-05', 'HIGH', 'N', 'TODO', '계약서 검토', 'CONTRACT', 2),
-    (5, NOW(), NOW(), '이메일 답변 작성', '2024-07-06', 'MEDIUM', 'N', 'TODO', '이메일 답변', 'EMAIL', 2);
+    (1, NOW(), NOW(), '고객사 자료 준비', '2024-10-10', 'HIGH', 'N', 'TODO', '자료 준비', 'SALES', 1),
+    (2, NOW(), NOW(), '팀 회의 참석', '2024-10-27', 'MEDIUM', 'N', 'INPROGRESS', '회의 참여', 'COMPANY', 1),
+    (3, NOW(), NOW(), '개인 일정 조율', '2024-09-29', 'LOW', 'Y', 'DONE', '일정 조율', 'PERSONAL', 1),
+    (4, NOW(), NOW(), '계약서 내용 확인', '2024-11-05', 'HIGH', 'N', 'TODO', '계약서 검토', 'CONTRACT', 1),
+    (5, NOW(), NOW(), '이메일 답변 작성', '2024-09-30', 'MEDIUM', 'N', 'TODO', '이메일 답변', 'EMAIL', 1);
 
 INSERT INTO tb_poetntial_customer (p_cust_no, created_at, updated_at, addr, cls, company, dept, email, fax, grade, modify_date, name, note, phone, position, register_date,tel)
 VALUES


### PR DESCRIPTION
## 📢 작업 내용 설명
- 회원가입 시 캘린더 생성하도록 추가
- 사용자 인증 기반으로 캘린더 조회 로직 추가
- 캘린더 존재 여부 확인 시 User 객체를 사용하도록 로직 개선
- 사용자 캘린더 생성 시 중복 생성 방지를 위한 검증 로직을 User 객체로 받도록 수정
- 사용자의 calendarNo를 기준으로 일정, 할 일, 영업활동 데이터를 통합 조회하는 서비스 로직 구현
- 캘린더 데이터에 포함된 일정, 할 일, 영업활동을 한 번에 조회하도록 Service 수정
<br>


## #️⃣연관된  issue
close #111

<br>



## ✅ 체크리스트
- [X] 새로운 기능 추가
- [X] 버그 수정
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 문서 수정

<br>


## 📑To Reviewers 

- 기존 로직 수정이라 캡처 올릴게 X
