### PR TITLE
[Feat/#122] 영업 예측 api 구현

### DIFF
--- a/src/main/java/beyond/samdasoo/admin/controller/DepartmentController.java
+++ b/src/main/java/beyond/samdasoo/admin/controller/DepartmentController.java
@@ -28,6 +28,14 @@ public class DepartmentController {
         return new BaseResponse<>(departments);
     }
 
+    @GetMapping("/child")
+    @Operation(summary = "모든 부서 조회", description = "관리자 계정에 등록된 모든 부서(트리구조 x)를 조회")
+    public BaseResponse<List<DepartmentDto>> getAllDepartments2(){
+        List<DepartmentDto> departments = departmentService.getAllDept2();
+
+        return new BaseResponse<>(departments);
+    }
+
     @PostMapping
     @Operation(summary = "부서 추가", description = "관리자 계정에 부서를 추가")
     public BaseResponse<String> addDepartment(@RequestBody DepartmentRequestDto request){

--- a/src/main/java/beyond/samdasoo/admin/dto/DepartmentDto.java
+++ b/src/main/java/beyond/samdasoo/admin/dto/DepartmentDto.java
@@ -1,5 +1,6 @@
 package beyond.samdasoo.admin.dto;
 
+import beyond.samdasoo.admin.entity.Department;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -38,5 +39,13 @@ public class DepartmentDto {
         this.deptHead = deptHead;
 
         this.upperDeptName = upperDeptName;
+    }
+
+    public DepartmentDto(Department department) {
+        this.no = department.getDeptNo();
+        this.name = department.getDeptName();
+        this.deptCode = department.getDeptCode();
+        this.engName = department.getEngName();
+        this.deptHead = department.getDeptHead();
     }
 }

--- a/src/main/java/beyond/samdasoo/admin/service/DepartmentService.java
+++ b/src/main/java/beyond/samdasoo/admin/service/DepartmentService.java
@@ -11,6 +11,8 @@ public interface DepartmentService {
 
     List<DepartmentDto> getAllDepartments();
 
+    List<DepartmentDto> getAllDept2();
+
     DepartmentResponseDto getDepartmentByNo(Long deptNo);
 
     void deleteDepartmentByNo(Long deptNo);

--- a/src/main/java/beyond/samdasoo/admin/service/DepartmentServiceImpl.java
+++ b/src/main/java/beyond/samdasoo/admin/service/DepartmentServiceImpl.java
@@ -6,7 +6,6 @@ import beyond.samdasoo.admin.dto.DepartmentResponseDto;
 import beyond.samdasoo.admin.entity.Department;
 import beyond.samdasoo.admin.repository.DepartmentRepository;
 import beyond.samdasoo.common.exception.BaseException;
-import beyond.samdasoo.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -14,13 +13,14 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static beyond.samdasoo.common.response.BaseResponseStatus.*;
 
 
 @Service
 @RequiredArgsConstructor
-public class DepartmentServiceImpl implements DepartmentService{
+public class DepartmentServiceImpl implements DepartmentService {
     @Autowired
     private final DepartmentRepository departmentRepository;
 
@@ -64,12 +64,18 @@ public class DepartmentServiceImpl implements DepartmentService{
         return result;
     }
 
+    @Override
+    public List<DepartmentDto> getAllDept2() {
+        return departmentRepository.findAll().stream()
+                .map(DepartmentDto::new).collect(Collectors.toList());
+    }
+
     private DepartmentDto departmentTree(Department department) {
 
         String upperDeptName = "";
 
-        if(department.getParent() != null){
-            Optional<Department> upperDept =  departmentRepository.findById(department.getParent().getDeptNo());
+        if (department.getParent() != null) {
+            Optional<Department> upperDept = departmentRepository.findById(department.getParent().getDeptNo());
 
             upperDeptName = upperDept.get().getDeptName();
 
@@ -93,7 +99,7 @@ public class DepartmentServiceImpl implements DepartmentService{
     public DepartmentResponseDto getDepartmentByNo(Long deptNo) {
         Optional<Department> optionalDepartment = departmentRepository.findById(deptNo);
 
-        if(optionalDepartment.isEmpty()){
+        if (optionalDepartment.isEmpty()) {
             throw new BaseException(DEPARTMENT_NOT_EXIST);
         }
 
@@ -104,7 +110,7 @@ public class DepartmentServiceImpl implements DepartmentService{
     public void deleteDepartmentByNo(Long deptNo) {
         Optional<Department> optionalDepartment = departmentRepository.findById(deptNo);
 
-        if(optionalDepartment.isEmpty()){
+        if (optionalDepartment.isEmpty()) {
             throw new BaseException(DEPARTMENT_NOT_EXIST);
         }
 
@@ -115,25 +121,25 @@ public class DepartmentServiceImpl implements DepartmentService{
     public void updateDepartmentByNo(Long deptNo, DepartmentRequestDto request) {
         Optional<Department> optionalDepartment = departmentRepository.findById(deptNo);
 
-        if(optionalDepartment.isEmpty()){
+        if (optionalDepartment.isEmpty()) {
             throw new BaseException(DEPARTMENT_NOT_EXIST);
         }
 
         Department department = optionalDepartment.get();
 
-        if(request.getEngName() != null){
+        if (request.getEngName() != null) {
             department.setEngName(request.getEngName());
         }
-        if(request.getDeptName() != null){
+        if (request.getDeptName() != null) {
             department.setDeptName(request.getDeptName());
         }
-        if(request.getDeptCode() != null){
+        if (request.getDeptCode() != null) {
             department.setDeptCode(request.getDeptCode());
         }
-        if(request.getDeptHead() != null){
+        if (request.getDeptHead() != null) {
             department.setDeptHead(request.getDeptHead());
         }
-        if(request.getUpperDeptName().equals(" ")){
+        if (request.getUpperDeptName().equals(" ")) {
             Optional<Department> optionalUpperDepartment = departmentRepository.findByDeptName(request.getUpperDeptName());
 
             if (optionalUpperDepartment.isEmpty()) {

--- a/src/main/java/beyond/samdasoo/common/config/SecurityConfig.java
+++ b/src/main/java/beyond/samdasoo/common/config/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests((auth) -> auth
 //                        .requestMatchers("/api/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll() // 테스트용
-                        .requestMatchers(HttpMethod.GET, "/api/admin/processes", "/api/admin/subprocesses/**", "/api/admin/departments").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/admin/processes", "/api/admin/subprocesses/**", "/api/admin/departments/**", "/api/admin/products").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/test/**", "/api/users/login", "/api/users/join",
                                 "/api/users/reissue", "/api/users/email/**", "/api/admin/targetsales/status/**","/api/users/reset-password-request","/api/users/reset-password").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")

--- a/src/main/java/beyond/samdasoo/common/dto/SearchCond.java
+++ b/src/main/java/beyond/samdasoo/common/dto/SearchCond.java
@@ -11,6 +11,9 @@ import java.time.LocalDate;
 @ToString
 public class SearchCond {
     private LocalDate searchDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private Long deptNo;
     private Long userNo;
+
 }

--- a/src/main/java/beyond/samdasoo/common/filter/AuthenticationFilter.java
+++ b/src/main/java/beyond/samdasoo/common/filter/AuthenticationFilter.java
@@ -90,7 +90,7 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
         response.addCookie(cookie);
 
         // 응답 객체 생성
-        LoginUserRes loginUserRes = new LoginUserRes(user.getUsername(),user.getEmail(),user.getUser().getRole(),access);
+        LoginUserRes loginUserRes = new LoginUserRes(user.getUser().getId(), user.getUser().getDepartment().getDeptNo(), user.getUsername(),user.getEmail(),user.getUser().getRole(),access);
 
         BaseResponse<LoginUserRes> responseObj = new BaseResponse<>(loginUserRes);
 

--- a/src/main/java/beyond/samdasoo/lead/Entity/AwarePath.java
+++ b/src/main/java/beyond/samdasoo/lead/Entity/AwarePath.java
@@ -1,12 +1,13 @@
 package beyond.samdasoo.lead.Entity;
 
 public enum AwarePath {
-    // 데모시연, 교육, 기존고객, 인터넷신문, 파트너사, 인터넷검색, 기타
-    DEMO,
-    EDUCATION,
     EXISTING,
+    ETC,
+    DEMO,
     NEWSPAPER,
-    PARTNER,
     SEARCH,
-    ETC
+    EDUCATION,
+    INTRODUCE,
+    PARTNER
+    // e기존고객, 기타, 데모체험, 신문, 인터넷검색, 정규교육, 지인소개, 파트너사
 }

--- a/src/main/java/beyond/samdasoo/lead/controller/LeadController.java
+++ b/src/main/java/beyond/samdasoo/lead/controller/LeadController.java
@@ -2,10 +2,7 @@ package beyond.samdasoo.lead.controller;
 
 import beyond.samdasoo.common.dto.SearchCond;
 import beyond.samdasoo.common.response.BaseResponse;
-import beyond.samdasoo.lead.dto.LeadRequestDto;
-import beyond.samdasoo.lead.dto.LeadResponseDto;
-import beyond.samdasoo.lead.dto.LeadSearchCond;
-import beyond.samdasoo.lead.dto.LeadStatusDto;
+import beyond.samdasoo.lead.dto.*;
 import beyond.samdasoo.lead.service.LeadService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -68,5 +65,23 @@ public class LeadController {
     public BaseResponse<List<LeadStatusDto>> getLeadStatusMain(@RequestBody SearchCond searchCond) {
         List<LeadStatusDto> leadStatus = leadService.getLeadStatusGroupedByStatus(searchCond);
         return new BaseResponse<>(leadStatus);
+    }
+
+    @PostMapping("/chart/month")
+    public BaseResponse<MonthResponseDto> getMonthlyChart(@RequestBody SearchCond searchCond) {
+        MonthResponseDto monthResponse = leadService.getMonthlyChart(searchCond);
+        return new BaseResponse<>(monthResponse);
+    }
+
+    @PostMapping("/chart/success")
+    public BaseResponse<List<SuccessChartDto>> getSuccessChart(@RequestBody SearchCond searchCond) {
+        List<SuccessChartDto> successChartDto = leadService.getSuccessChart(searchCond);
+        return new BaseResponse<>(successChartDto);
+    }
+
+    @PostMapping("/chart/path")
+    public BaseResponse<List<AwarePathResponseDto>> getPathChart(@RequestBody SearchCond searchCond) {
+        List<AwarePathResponseDto> pathChartDto = leadService.getPathChart(searchCond);
+        return new BaseResponse<>(pathChartDto);
     }
 }

--- a/src/main/java/beyond/samdasoo/lead/dto/AwarePathResponseDto.java
+++ b/src/main/java/beyond/samdasoo/lead/dto/AwarePathResponseDto.java
@@ -1,0 +1,22 @@
+package beyond.samdasoo.lead.dto;
+
+import beyond.samdasoo.lead.Entity.AwarePath;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+@Data
+public class AwarePathResponseDto {
+    private AwarePath awarePath;
+    private Long totalExpSales;
+    private Long totalExpProfit;
+    private Long leadCount;
+
+    @QueryProjection
+    public AwarePathResponseDto(AwarePath awarePath, Long totalExpSales, Long totalExpProfit, Long leadCount) {
+        this.awarePath = awarePath;
+        this.totalExpSales = totalExpSales != null ? totalExpSales : 0;
+        this.totalExpProfit = totalExpProfit != null ? totalExpProfit : 0;
+        this.leadCount = leadCount != null ? leadCount : 0;
+    }
+
+}

--- a/src/main/java/beyond/samdasoo/lead/dto/LeadSearchCond.java
+++ b/src/main/java/beyond/samdasoo/lead/dto/LeadSearchCond.java
@@ -1,5 +1,6 @@
 package beyond.samdasoo.lead.dto;
 
+import beyond.samdasoo.common.dto.SearchCond;
 import beyond.samdasoo.lead.Entity.LeadStatus;
 import lombok.Getter;
 import lombok.ToString;
@@ -8,10 +9,16 @@ import java.time.LocalDate;
 
 @Getter
 @ToString
-public class LeadSearchCond {
-    private LeadStatus status;
-    private Long process;
-    private Long subProcess;
-    private LocalDate startDate;
-    private LocalDate endDate;
+public class LeadSearchCond extends SearchCond {
+    private final LeadStatus status;
+    private final Long process;
+    private final Long subProcess;
+
+    public LeadSearchCond(LocalDate searchDate, LocalDate startDate, LocalDate endDate, Long deptNo, Long userNo,
+                          LeadStatus status, Long process, Long subProcess) {
+        super(searchDate, startDate, endDate, deptNo, userNo); // 부모 클래스의 생성자를 호출합니다.
+        this.status = status;
+        this.process = process;
+        this.subProcess = subProcess;
+    }
 }

--- a/src/main/java/beyond/samdasoo/lead/dto/LeadStatusDto.java
+++ b/src/main/java/beyond/samdasoo/lead/dto/LeadStatusDto.java
@@ -9,4 +9,5 @@ import lombok.Getter;
 public class LeadStatusDto {
     private LeadStatus status;
     private long count;
+    private int amt;
 }

--- a/src/main/java/beyond/samdasoo/lead/dto/MonthResponseDto.java
+++ b/src/main/java/beyond/samdasoo/lead/dto/MonthResponseDto.java
@@ -1,0 +1,17 @@
+package beyond.samdasoo.lead.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class MonthResponseDto {
+    private List<Integer> monthExpSales;
+    private List<Integer> monthExpProfit;
+    private List<Integer> monthLeadCount;
+    private int totalSales;
+    private int totalProfit;
+    private int totalLeadCount;
+}

--- a/src/main/java/beyond/samdasoo/lead/dto/SuccessChartDto.java
+++ b/src/main/java/beyond/samdasoo/lead/dto/SuccessChartDto.java
@@ -1,0 +1,16 @@
+package beyond.samdasoo.lead.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+@Data
+public class SuccessChartDto {
+    private int successPer;
+    private long count;
+
+    @QueryProjection
+    public SuccessChartDto(int successPer, long count) {
+        this.successPer = successPer;
+        this.count = count;
+    }
+}

--- a/src/main/java/beyond/samdasoo/lead/repository/LeadRepository.java
+++ b/src/main/java/beyond/samdasoo/lead/repository/LeadRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
-public interface LeadRepository extends JpaRepository<Lead, Long> {
+public interface LeadRepository extends JpaRepository<Lead, Long>, LeadRepositoryCustom {
     @Query("SELECT l FROM Lead l JOIN FETCH l.steps WHERE l.no = :leadNo")
     Optional<Lead> findByIdWithSteps(@Param("leadNo") Long leadNo);
 }

--- a/src/main/java/beyond/samdasoo/lead/repository/LeadRepositoryCustom.java
+++ b/src/main/java/beyond/samdasoo/lead/repository/LeadRepositoryCustom.java
@@ -1,10 +1,18 @@
 package beyond.samdasoo.lead.repository;
 
 import beyond.samdasoo.common.dto.SearchCond;
-import beyond.samdasoo.lead.dto.LeadStatusDto;
+import beyond.samdasoo.lead.dto.*;
 
 import java.util.List;
 
 public interface LeadRepositoryCustom {
+    List<LeadResponseDto> findFilteredLeads(LeadSearchCond searchCond);
+
     List<LeadStatusDto> findLeadStatusGroupedByStatus(SearchCond searchCond);
+
+    MonthResponseDto findMonthlyLeadData(SearchCond searchCond);
+
+    List<SuccessChartDto> findSuccessData(SearchCond searchCond);
+
+    List<AwarePathResponseDto> findLeadDataByAwarePath(SearchCond searchCond);
 }

--- a/src/main/java/beyond/samdasoo/lead/repository/LeadRepositoryImpl.java
+++ b/src/main/java/beyond/samdasoo/lead/repository/LeadRepositoryImpl.java
@@ -2,33 +2,222 @@ package beyond.samdasoo.lead.repository;
 
 import beyond.samdasoo.common.dto.SearchCond;
 import beyond.samdasoo.customer.entity.QCustomer;
+import beyond.samdasoo.lead.Entity.AwarePath;
+import beyond.samdasoo.lead.Entity.Lead;
+import beyond.samdasoo.lead.Entity.LeadStatus;
 import beyond.samdasoo.lead.Entity.QLead;
-import beyond.samdasoo.lead.dto.LeadStatusDto;
+import beyond.samdasoo.lead.dto.*;
 import beyond.samdasoo.user.repository.UserRepository;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
-public class LeadRepositoryImpl implements LeadRepositoryCustom{
+public class LeadRepositoryImpl implements LeadRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private final UserRepository userRepository;
 
+    QLead lead = QLead.lead;
+    QCustomer customer = QCustomer.customer;
+    BooleanBuilder builder;
+
+    @Override
+    public List<LeadResponseDto> findFilteredLeads(LeadSearchCond searchCond) {
+        builder = new BooleanBuilder();
+
+        if (searchCond.getStartDate() != null) {
+            builder.and(lead.startDate.goe(searchCond.getStartDate()));
+        }
+
+        if (searchCond.getEndDate() != null) {
+            builder.and(lead.endDate.loe(searchCond.getEndDate()));
+        }
+
+        if (searchCond.getStatus() != null) {
+            builder.and(lead.status.eq(searchCond.getStatus()));
+        }
+
+        if (searchCond.getProcess() != null && searchCond.getProcess() > 0) {
+            builder.and(lead.process.eq(searchCond.getProcess()));
+        }
+
+        if (searchCond.getSubProcess() != null && searchCond.getSubProcess() > 0) {
+            builder.and(lead.subProcess.eq(searchCond.getSubProcess()));
+        }
+
+        if (searchCond.getDeptNo() != null && searchCond.getDeptNo() > 0) {
+            List<Long> deptNos = userRepository.findAllSubDepartments(searchCond.getDeptNo());
+
+            builder.and(customer.user.department.deptNo.in(deptNos));
+        }
+
+        if (searchCond.getUserNo() != null && searchCond.getUserNo() > 0) {
+            builder.and(customer.user.id.eq(searchCond.getUserNo()));
+        }
+
+        List<Lead> leads = queryFactory
+                .selectFrom(lead)
+                .where(builder)  // 동적 조건
+                .fetch();
+
+        return leads.stream()
+                .map(LeadResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
     @Override
     public List<LeadStatusDto> findLeadStatusGroupedByStatus(SearchCond searchCond) {
-        QLead lead = QLead.lead;
-        QCustomer customer = QCustomer.customer;
-
-        BooleanBuilder builder = new BooleanBuilder();
+        List<LeadStatusDto> results;
+        builder = new BooleanBuilder();
 
         if (searchCond.getSearchDate() != null) {
-            builder.and(lead.startDate.loe(searchCond.getSearchDate()));
+            builder.and(lead.endDate.loe(searchCond.getSearchDate()));
+        }
+
+        if (searchCond.getStartDate() != null) {
+            builder.and(lead.endDate.goe(searchCond.getStartDate()));
+        }
+
+        if (searchCond.getEndDate() != null) {
+            builder.and(lead.endDate.lt(searchCond.getEndDate()));
+        }
+
+        if (searchCond.getDeptNo() != null && searchCond.getDeptNo() > 0) {
+            List<Long> deptNos = userRepository.findAllSubDepartments(searchCond.getDeptNo());
+
+            builder.and(customer.user.department.deptNo.in(deptNos));
+        }
+
+        if (searchCond.getUserNo() != null && searchCond.getUserNo() > 0) {
+            builder.and(customer.user.id.eq(searchCond.getUserNo()));
+        }
+
+        results = queryFactory
+                .select(Projections.constructor(LeadStatusDto.class,
+                        lead.status,
+                        lead.count().as("count"),
+                        Expressions.numberTemplate(Integer.class, "floor({0} / 1000)", lead.expSales.sum().coalesce(0L))
+                ))
+                .from(lead)
+                .join(lead.customer, customer)
+                .where(builder)
+                .groupBy(lead.status)
+                .fetch();
+
+        List<LeadStatusDto> completeResults = new ArrayList<>();
+
+        long totalCnt = results.stream().mapToLong(LeadStatusDto::getCount).sum();
+        int totalAmt = results.stream().mapToInt(LeadStatusDto::getAmt).sum();
+
+        for (LeadStatus status : LeadStatus.values()) {
+            completeResults.add(
+                    results.stream()
+                            .filter(dto -> dto.getStatus() == status)
+                            .findFirst()
+                            .orElse(new LeadStatusDto(status, 0L, 0))
+            );
+        }
+
+        completeResults.addFirst(new LeadStatusDto(null, totalCnt, totalAmt));
+
+        return completeResults;
+    }
+
+    @Override
+    public MonthResponseDto findMonthlyLeadData(SearchCond searchCond) {
+        builder = new BooleanBuilder();
+
+        if (searchCond.getStartDate() != null) {
+            builder.and(lead.endDate.goe(searchCond.getStartDate()));
+        }
+
+        if (searchCond.getEndDate() != null) {
+            builder.and(lead.endDate.lt(searchCond.getEndDate()));
+        }
+
+        if (searchCond.getDeptNo() != null && searchCond.getDeptNo() > 0) {
+            List<Long> deptNos = userRepository.findAllSubDepartments(searchCond.getDeptNo());
+
+            builder.and(customer.user.department.deptNo.in(deptNos));
+        }
+
+        if (searchCond.getUserNo() != null && searchCond.getUserNo() > 0) {
+            builder.and(customer.user.id.eq(searchCond.getUserNo()));
+        }
+
+        List<Tuple> salesData = queryFactory
+                .select(lead.endDate.month(), Expressions.numberTemplate(Integer.class, "floor({0} / 1000)", lead.expSales.sum().coalesce(0L)))
+                .from(lead)
+                .where(builder.and(
+                        lead.endDate.year().eq(searchCond.getStartDate().getYear()))
+                )
+                .groupBy(lead.endDate.month())
+                .fetch();
+
+        List<Tuple> profitData = queryFactory
+                .select(lead.endDate.month(), Expressions.numberTemplate(Integer.class, "floor({0} / 1000)", lead.expProfit.sum().coalesce(0L)))
+                .from(lead)
+                .where(builder.and(
+                        lead.endDate.year().eq(searchCond.getEndDate().getYear()))
+                )
+                .groupBy(lead.endDate.month())
+                .fetch();
+
+        List<Tuple> leadCountData = queryFactory
+                .select(lead.endDate.month(), lead.count().intValue())
+                .from(lead)
+                .where(builder.and(
+                        lead.endDate.year().eq(searchCond.getStartDate().getYear()))
+                )
+                .groupBy(lead.endDate.month())
+                .fetch();
+
+        List<Integer> monthExpSales = initializeMonthlyData();
+        List<Integer> monthExpProfit = initializeMonthlyData();
+        List<Integer> monthLeadCount = initializeMonthlyData();
+
+        salesData.forEach(tuple -> monthExpSales.set(tuple.get(lead.endDate.month()) - 1, tuple.get(1, Integer.class)));
+        profitData.forEach(tuple -> monthExpProfit.set(tuple.get(lead.endDate.month()) - 1, tuple.get(1, Integer.class)));
+        leadCountData.forEach(tuple -> monthLeadCount.set(tuple.get(lead.endDate.month()) - 1, tuple.get(1, Integer.class)));
+
+        int totalSales = 0;
+        int totalProfit = 0;
+        int totalLeadCount = 0;
+
+        for (Integer month : monthExpSales) {
+            totalSales += month;
+        }
+
+        for (Integer month : monthExpProfit) {
+            totalProfit += month;
+        }
+
+        for (Integer month : monthLeadCount) {
+            totalLeadCount += month;
+        }
+
+        return new MonthResponseDto(monthExpSales, monthExpProfit, monthLeadCount, totalSales, totalProfit, totalLeadCount);
+    }
+
+    @Override
+    public List<SuccessChartDto> findSuccessData(SearchCond searchCond) {
+        builder = new BooleanBuilder();
+
+        if (searchCond.getStartDate() != null) {
+            builder.and(lead.endDate.goe(searchCond.getStartDate()));
+        }
+
+        if (searchCond.getEndDate() != null) {
+            builder.and(lead.endDate.lt(searchCond.getEndDate()));
         }
 
         if (searchCond.getDeptNo() != null && searchCond.getDeptNo() > 0) {
@@ -42,14 +231,70 @@ public class LeadRepositoryImpl implements LeadRepositoryCustom{
         }
 
         return queryFactory
-                .select(Projections.constructor(LeadStatusDto.class,
-                        lead.status,
-                        lead.count().as("count")
+                .select(new QSuccessChartDto(
+                        lead.successPer,
+                        lead.count()
                 ))
                 .from(lead)
-                .join(lead.customer, customer)
                 .where(builder)
-                .groupBy(lead.status)
+                .groupBy(lead.successPer)
                 .fetch();
+    }
+
+    @Override
+    public List<AwarePathResponseDto> findLeadDataByAwarePath(SearchCond searchCond) {
+        builder = new BooleanBuilder();
+
+        if (searchCond.getStartDate() != null) {
+            builder.and(lead.endDate.goe(searchCond.getStartDate()));
+        }
+
+        if (searchCond.getEndDate() != null) {
+            builder.and(lead.endDate.lt(searchCond.getEndDate()));
+        }
+
+        if (searchCond.getDeptNo() != null && searchCond.getDeptNo() > 0) {
+            List<Long> deptNos = userRepository.findAllSubDepartments(searchCond.getDeptNo());
+
+            builder.and(customer.user.department.deptNo.in(deptNos));
+        }
+
+        if (searchCond.getUserNo() != null && searchCond.getUserNo() > 0) {
+            builder.and(customer.user.id.eq(searchCond.getUserNo()));
+        }
+
+        List<AwarePathResponseDto> results = queryFactory
+                .select(
+                        new QAwarePathResponseDto(
+                                lead.awarePath,
+                                lead.expSales.sum(),
+                                lead.expProfit.sum(),
+                                lead.count()
+                        )
+                )
+                .from(lead)
+                .where(builder)
+                .groupBy(lead.awarePath)
+                .fetch();
+
+        List<AwarePathResponseDto> completeResults = new ArrayList<>();
+        for (AwarePath path : AwarePath.values()) {
+            completeResults.add(
+                    results.stream()
+                            .filter(dto -> dto.getAwarePath() == path)
+                            .findFirst()
+                            .orElse(new AwarePathResponseDto(path, 0L, 0L, 0L))
+            );
+        }
+
+        return completeResults;
+    }
+
+    private List<Integer> initializeMonthlyData() {
+        List<Integer> data = new ArrayList<>();
+        for (int i = 0; i < 12; i++) {
+            data.add(0);
+        }
+        return data;
     }
 }

--- a/src/main/java/beyond/samdasoo/user/dto/LoginUserRes.java
+++ b/src/main/java/beyond/samdasoo/user/dto/LoginUserRes.java
@@ -1,18 +1,17 @@
 package beyond.samdasoo.user.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 
-//@Builder
 @Getter
 @AllArgsConstructor
 public class LoginUserRes {
 
+    private Long userNo;
+    private Long deptNo;
     private String name;
     private String email;
     private UserRole role;
-  //  private String dept;
     private String accessToken;
 
 


### PR DESCRIPTION
close #122

## 📢 작업 내용 설명
> 영업예측 api 구현
로그인 res - userNo, deptNo 추가
부서조회 - 트리구조없이 추가
시큐리티 config 패턴 추가

<br>

## #️⃣연관된  issue
#122 

<br>

## ✅ 체크리스트
- [ ] 새로운 기능 추가
- [ ] 코드 리팩토링
